### PR TITLE
Create structured documentation and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,211 +4,46 @@
 
 Photo Administration toolbox - Python utility for analyzing photo collections
 
-## Features
-
-- **Configurable File Types**: Support for customizable photo and metadata file extensions via YAML configuration
-- **File Scanning**: Recursively scans folders for configured photo and XMP files
-- **Statistics Collection**: Counts files by type and calculates storage usage
-- **File Pairing Analysis**: Identifies orphaned images and XMP metadata files
-- **XMP Metadata Extraction**: Parses and analyzes metadata from XMP sidecar files
-- **HTML Reports**: Generates beautiful, interactive HTML reports with charts
-
-## Installation
-
-1. Clone this repository
-2. Install dependencies:
+## Quick Start
 
 ```bash
+# Clone the repository
+git clone https://github.com/fabrice-guiot/photo-admin.git
+cd photo-admin
+
+# Install dependencies
 pip install -r requirements.txt
+
+# Run PhotoStats (first run will prompt for configuration)
+python photo_stats.py /path/to/your/photos
 ```
 
-## Usage
+## Documentation
 
-Basic usage:
+- **[Installation Guide](docs/installation.md)** - Detailed installation instructions
+- **[Configuration Guide](docs/configuration.md)** - How to configure file types and settings
+- **[PhotoStats Tool](docs/photostats.md)** - Complete guide to using the PhotoStats tool
+
+## Tools
+
+### PhotoStats
+
+PhotoStats analyzes photo collections and generates detailed HTML reports with statistics and charts.
+
+**Features:**
+- Configurable file type support for any RAW or image format
+- Recursive folder scanning
+- File pairing analysis (images with/without XMP sidecars)
+- XMP metadata extraction
+- Interactive HTML reports with charts
+
+**Quick Usage:**
 
 ```bash
 python photo_stats.py /path/to/your/photos
 ```
 
-Specify custom output file:
-
-```bash
-python photo_stats.py /path/to/your/photos my_report.html
-```
-
-Specify a custom configuration file:
-
-```bash
-python photo_stats.py /path/to/your/photos my_report.html config/config.yaml
-```
-
-The tool will:
-1. Load configuration (if available) to determine which file types to scan
-2. Scan the specified folder recursively
-3. Collect statistics on all configured photo files and metadata files
-4. Analyze file pairing (images with/without XMP files)
-5. Extract and analyze XMP metadata
-6. Generate an HTML report with interactive charts
-
-## Configuration
-
-**Configuration is required** to run this tool. The tool uses a YAML configuration file to specify which file types should be treated as photos and which should have XMP sidecars.
-
-### First-Time Setup
-
-When you run the tool for the first time without a configuration file, it will:
-
-1. **Automatically detect** that no configuration exists
-2. **Prompt you** to create one from the template
-3. **Create the config file** for you if you accept (just press Enter)
-
-Example:
-```
-$ python photo_stats.py /path/to/photos
-
-No configuration file found.
-Template found at: config/template-config.yaml
-
-Would you like to create a configuration file at: config/config.yaml
-Create config file? [Y/n]:
-
-✓ Configuration file created: config/config.yaml
-
-You can now modify this file to customize file type settings for your needs.
-The tool will use this configuration for all future runs.
-```
-
-### Manual Configuration Setup
-
-You can also manually create your configuration:
-
-```bash
-cp config/template-config.yaml config/config.yaml
-```
-
-Then edit `config/config.yaml` to customize the file extensions for your needs.
-
-**Note:** The `config/config.yaml` file is ignored by git, so your personal configuration won't be committed.
-
-### Configuration File Locations
-
-The tool will automatically look for configuration files in the following locations (in order):
-1. `config/config.yaml` in the current directory
-2. `config.yaml` in the current directory
-3. `~/.photo_stats_config.yaml` in your home directory
-4. `config/config.yaml` in the script directory
-
-You can also explicitly specify a configuration file as the third command-line argument.
-
-### Configuration File Format
-
-The configuration file uses YAML format with three key sections:
-
-1. **photo_extensions**: All file types to scan and count
-2. **require_sidecar**: File types that MUST have XMP sidecars (orphaned if missing)
-3. **metadata_extensions**: Valid sidecar file extensions
-
-See `config/template-config.yaml` for a complete example:
-
-```yaml
-# Photo Statistics Configuration
-
-# File types that should be scanned
-photo_extensions:
-  - .dng      # DNG files (already contain metadata, no sidecar needed)
-  - .tiff     # TIFF files (already contain metadata, no sidecar needed)
-  - .tif      # TIFF files (already contain metadata, no sidecar needed)
-  - .cr3      # Canon CR3 RAW (requires XMP sidecar)
-  - .nef      # Nikon RAW (requires XMP sidecar)
-  # Add more formats as needed
-
-# File types that REQUIRE XMP sidecar files
-# Only these will be flagged as "orphaned" if missing sidecars
-require_sidecar:
-  - .cr3
-  - .nef
-  # Note: DNG and TIFF embed metadata, so they don't need sidecars
-
-# Valid metadata sidecar file extensions
-metadata_extensions:
-  - .xmp
-```
-
-### Understanding File Pairing
-
-**Key Concept**: Not all photo files need XMP sidecars!
-
-- **DNG and TIFF** files embed their metadata internally, so they don't need sidecars
-- **RAW formats** (CR3, NEF, ARW, etc.) typically require external XMP files for metadata
-
-The `require_sidecar` setting lets you specify which formats need sidecars in YOUR workflow. Only files listed there will be flagged as "orphaned" when they lack an XMP file.
-
-### Template Configuration
-
-The template file (`config/template-config.yaml`) provides default settings:
-- **Photo extensions**: `.dng`, `.tiff`, `.tif`, `.cr3`
-- **Require sidecar**: `.cr3` only
-- **Metadata extensions**: `.xmp`
-
-You can uncomment additional format options in the template or add your own custom extensions.
-
-## Output
-
-The tool generates an HTML report containing:
-
-- **Summary Statistics**: Total images (excluding sidecars), total size, orphaned images count, orphaned sidecars count
-- **Image Type Distribution Chart**: Visual breakdown of image file counts (sidecars excluded except orphaned ones)
-- **Storage Distribution Chart**: Storage usage by image type, combining each image with its paired sidecar size
-- **Pairing Status**: Lists of orphaned images and XMP sidecar files
-
-## Example Output
-
-```
-Scanning folder: /Users/you/Photos
-Found 1234 files
-Analyzing file pairing...
-Extracting XMP metadata...
-Scan completed in 2.45 seconds
-Generating HTML report: photo_stats_report.html
-
-==================================================
-SUMMARY
-==================================================
-Total files: 1234
-Total size: 45.67 GB
-Paired files: 580
-Orphaned images: 12
-Orphaned XMP: 3
-
-File counts:
-  .CR3: 600
-  .DNG: 150
-  .TIFF: 432
-  .XMP: 52
-
-==================================================
-
-✓ HTML report saved to: /path/to/photo_stats_report.html
-```
-
-## Supported File Types
-
-The tool is configurable and can support any RAW or image format. By default, it supports:
-
-- **DNG** (Digital Negative)
-- **TIFF** (Tagged Image File Format)
-- **CR3** (Canon Raw 3)
-- **XMP** (Extensible Metadata Platform)
-
-Additional formats can be added via the configuration file, including:
-- **NEF** (Nikon RAW)
-- **ARW** (Sony RAW)
-- **ORF** (Olympus RAW)
-- **RW2** (Panasonic RAW)
-- **PEF** (Pentax RAW)
-- **RAF** (Fujifilm RAW)
-- **CR2** (Canon RAW, older format)
-- **RAW**, **CRW**, and other manufacturer-specific formats
+See the [PhotoStats documentation](docs/photostats.md) for complete usage details.
 
 ## Development
 
@@ -258,6 +93,10 @@ photo-admin/
 ├── config/
 │   ├── template-config.yaml    # Configuration template
 │   └── config.yaml             # User configuration (gitignored)
+├── docs/                       # Documentation
+│   ├── installation.md         # Installation guide
+│   ├── configuration.md        # Configuration guide
+│   └── photostats.md           # PhotoStats tool documentation
 ├── requirements.txt            # Python dependencies
 ├── pytest.ini                 # Pytest configuration
 ├── .coveragerc                # Coverage configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,122 @@
+# Configuration
+
+**Configuration is required** to run this tool. The tool uses a YAML configuration file to specify which file types should be treated as photos and which should have XMP sidecars.
+
+## First-Time Setup
+
+When you run the tool for the first time without a configuration file, it will:
+
+1. **Automatically detect** that no configuration exists
+2. **Prompt you** to create one from the template
+3. **Create the config file** for you if you accept (just press Enter)
+
+Example:
+```
+$ python photo_stats.py /path/to/photos
+
+No configuration file found.
+Template found at: config/template-config.yaml
+
+Would you like to create a configuration file at: config/config.yaml
+Create config file? [Y/n]:
+
+✓ Configuration file created: config/config.yaml
+
+You can now modify this file to customize file type settings for your needs.
+The tool will use this configuration for all future runs.
+```
+
+## Manual Configuration Setup
+
+You can also manually create your configuration:
+
+```bash
+cp config/template-config.yaml config/config.yaml
+```
+
+Then edit `config/config.yaml` to customize the file extensions for your needs.
+
+**Note:** The `config/config.yaml` file is ignored by git, so your personal configuration won't be committed.
+
+## Configuration File Locations
+
+The tool will automatically look for configuration files in the following locations (in order):
+1. `config/config.yaml` in the current directory
+2. `config.yaml` in the current directory
+3. `~/.photo_stats_config.yaml` in your home directory
+4. `config/config.yaml` in the script directory
+
+You can also explicitly specify a configuration file as the third command-line argument:
+
+```bash
+python photo_stats.py /path/to/photos report.html config/custom-config.yaml
+```
+
+## Configuration File Format
+
+The configuration file uses YAML format with three key sections:
+
+1. **photo_extensions**: All file types to scan and count
+2. **require_sidecar**: File types that MUST have XMP sidecars (orphaned if missing)
+3. **metadata_extensions**: Valid sidecar file extensions
+
+See `config/template-config.yaml` for a complete example:
+
+```yaml
+# Photo Statistics Configuration
+
+# File types that should be scanned
+photo_extensions:
+  - .dng      # DNG files (already contain metadata, no sidecar needed)
+  - .tiff     # TIFF files (already contain metadata, no sidecar needed)
+  - .tif      # TIFF files (already contain metadata, no sidecar needed)
+  - .cr3      # Canon CR3 RAW (requires XMP sidecar)
+  - .nef      # Nikon RAW (requires XMP sidecar)
+  # Add more formats as needed
+
+# File types that REQUIRE XMP sidecar files
+# Only these will be flagged as "orphaned" if missing sidecars
+require_sidecar:
+  - .cr3
+  - .nef
+  # Note: DNG and TIFF embed metadata, so they don't need sidecars
+
+# Valid metadata sidecar file extensions
+metadata_extensions:
+  - .xmp
+```
+
+## Understanding File Pairing
+
+**Key Concept**: Not all photo files need XMP sidecars!
+
+- **DNG and TIFF** files embed their metadata internally, so they don't need sidecars
+- **RAW formats** (CR3, NEF, ARW, etc.) typically require external XMP files for metadata
+
+The `require_sidecar` setting lets you specify which formats need sidecars in YOUR workflow. Only files listed there will be flagged as "orphaned" when they lack an XMP file.
+
+## Template Configuration
+
+The template file (`config/template-config.yaml`) provides default settings:
+- **Photo extensions**: `.dng`, `.tiff`, `.tif`, `.cr3`
+- **Require sidecar**: `.cr3` only
+- **Metadata extensions**: `.xmp`
+
+You can uncomment additional format options in the template or add your own custom extensions.
+
+## Supported File Types
+
+The tool is configurable and can support any RAW or image format. Additional formats that can be added via the configuration file include:
+
+- **NEF** (Nikon RAW)
+- **ARW** (Sony RAW)
+- **ORF** (Olympus RAW)
+- **RW2** (Panasonic RAW)
+- **PEF** (Pentax RAW)
+- **RAF** (Fujifilm RAW)
+- **CR2** (Canon RAW, older format)
+- **RAW**, **CRW**, and other manufacturer-specific formats
+
+## Next Steps
+
+After configuring the tool, see the [PhotoStats documentation](photostats.md) to learn how to use it.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,54 @@
+# Installation
+
+This guide covers installing the photo-admin toolbox.
+
+## Requirements
+
+- Python 3.x
+- pip package manager
+- Git (for cloning the repository)
+
+## Installation Steps
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/fabrice-guiot/photo-admin.git
+cd photo-admin
+```
+
+### 2. Install Dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+## Verify Installation
+
+To verify that the installation was successful, you can run:
+
+```bash
+python photo_stats.py --help
+```
+
+This should display usage information without any errors.
+
+## Next Steps
+
+After installation, you'll need to configure the tool before first use. See the [Configuration Guide](configuration.md) for details on setting up your configuration file.
+
+## Development Installation
+
+If you plan to contribute to the project or run tests, install the development dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then you can run the test suite:
+
+```bash
+python -m pytest tests/ -v
+```
+
+For more information on testing, see the Development section in the main [README](../README.md).

--- a/docs/photostats.md
+++ b/docs/photostats.md
@@ -1,0 +1,190 @@
+# PhotoStats Tool
+
+PhotoStats is a Python utility for analyzing photo collections, providing detailed statistics and reports about your photo library.
+
+## Features
+
+- **Configurable File Types**: Support for customizable photo and metadata file extensions via YAML configuration
+- **File Scanning**: Recursively scans folders for configured photo and XMP files
+- **Statistics Collection**: Counts files by type and calculates storage usage
+- **File Pairing Analysis**: Identifies orphaned images and XMP metadata files
+- **XMP Metadata Extraction**: Parses and analyzes metadata from XMP sidecar files
+- **HTML Reports**: Generates beautiful, interactive HTML reports with charts
+
+## Prerequisites
+
+Before using PhotoStats, make sure you have:
+1. [Installed the tool](installation.md)
+2. [Configured the file types](configuration.md) you want to scan
+
+## Usage
+
+### Basic Usage
+
+Scan a folder and generate a report:
+
+```bash
+python photo_stats.py /path/to/your/photos
+```
+
+This will:
+1. Load configuration to determine which file types to scan
+2. Scan the specified folder recursively
+3. Collect statistics on all configured photo files and metadata files
+4. Analyze file pairing (images with/without XMP files)
+5. Extract and analyze XMP metadata
+6. Generate an HTML report named `photo_stats_report.html` in the current directory
+
+### Custom Output File
+
+Specify a custom output filename:
+
+```bash
+python photo_stats.py /path/to/your/photos my_report.html
+```
+
+### Custom Configuration File
+
+Use a specific configuration file:
+
+```bash
+python photo_stats.py /path/to/your/photos my_report.html config/config.yaml
+```
+
+## What PhotoStats Analyzes
+
+The tool performs several types of analysis on your photo collection:
+
+1. **File Type Distribution**: Counts how many files of each type exist
+2. **Storage Analysis**: Calculates total storage used by each file type
+3. **Pairing Analysis**: Identifies which images have corresponding XMP sidecars and which don't
+4. **Orphan Detection**: Finds XMP files without matching images and images without required sidecars
+5. **Metadata Extraction**: Parses XMP files to extract embedded metadata
+
+## Output
+
+### Console Output
+
+The tool provides progress information and a summary in the console:
+
+```
+Scanning folder: /Users/you/Photos
+Found 1234 files
+Analyzing file pairing...
+Extracting XMP metadata...
+Scan completed in 2.45 seconds
+Generating HTML report: photo_stats_report.html
+
+==================================================
+SUMMARY
+==================================================
+Total files: 1234
+Total size: 45.67 GB
+Paired files: 580
+Orphaned images: 12
+Orphaned XMP: 3
+
+File counts:
+  .CR3: 600
+  .DNG: 150
+  .TIFF: 432
+  .XMP: 52
+
+==================================================
+
+✓ HTML report saved to: /path/to/photo_stats_report.html
+```
+
+### HTML Report
+
+The generated HTML report contains:
+
+- **Summary Statistics**:
+  - Total images (excluding sidecars)
+  - Total size
+  - Orphaned images count
+  - Orphaned sidecars count
+
+- **Image Type Distribution Chart**:
+  - Visual breakdown of image file counts
+  - Sidecars excluded except orphaned ones
+
+- **Storage Distribution Chart**:
+  - Storage usage by image type
+  - Combines each image with its paired sidecar size
+
+- **Pairing Status**:
+  - Lists of orphaned images (missing required sidecars)
+  - Lists of orphaned XMP sidecar files (no matching image)
+
+## Understanding the Results
+
+### Paired Files
+
+Images that have matching XMP sidecar files (e.g., `IMG_001.CR3` paired with `IMG_001.xmp`).
+
+### Orphaned Images
+
+Images that require XMP sidecars (based on your configuration's `require_sidecar` setting) but don't have one. This might indicate:
+- Missing metadata files
+- Files that haven't been processed yet
+- Potential data loss
+
+### Orphaned XMP Files
+
+XMP sidecar files that don't have a matching image file. This might indicate:
+- Deleted images but metadata retained
+- Naming mismatches
+- Files that need cleanup
+
+## Examples
+
+### Scan a photo library
+
+```bash
+python photo_stats.py ~/Pictures/2024
+```
+
+### Generate a report for a specific project
+
+```bash
+python photo_stats.py /Volumes/Photos/Wedding_Project wedding_stats.html
+```
+
+### Use a custom configuration for RAW files
+
+```bash
+python photo_stats.py ~/Photos/RAW raw_report.html config/raw-only-config.yaml
+```
+
+## Tips
+
+- **Large Collections**: For very large photo collections, the scan may take several minutes. The tool provides progress updates.
+- **Network Drives**: Scanning network drives will be slower than local drives.
+- **Configuration**: Adjust your configuration file to match your specific workflow and file types.
+- **Regular Checks**: Run PhotoStats periodically to ensure your photo collection integrity.
+
+## Troubleshooting
+
+### No configuration file found
+
+If you see this message, follow the prompts to create a configuration file from the template, or see the [Configuration Guide](configuration.md).
+
+### No files found
+
+This might mean:
+- The folder path is incorrect
+- No files match your configured file types
+- The folder is empty
+
+Check your configuration and folder path.
+
+### Report not generated
+
+Ensure you have write permissions in the output directory.
+
+## Next Steps
+
+- Learn more about [configuration options](configuration.md)
+- Check out the [Installation guide](installation.md) for development setup
+- See the main [README](../README.md) for information about running tests


### PR DESCRIPTION
- Create docs/ folder to organize documentation
- Add docs/installation.md: Detailed installation guide with prerequisites and verification steps
- Add docs/configuration.md: Comprehensive configuration guide covering first-time setup, file locations, and file pairing concepts
- Add docs/photostats.md: Complete PhotoStats tool documentation with features, usage examples, and troubleshooting
- Simplify README.md: Remove detailed content and add links to specialized documentation
- Update project structure in README to reflect new docs/ folder

This reorganization makes documentation more discoverable and maintainable
as the toolbox grows with additional tools.