### PR TITLE
fix: Filter inactive categories from EventForm dropdown when creating events

### DIFF
--- a/frontend/src/components/events/EventForm.tsx
+++ b/frontend/src/components/events/EventForm.tsx
@@ -391,6 +391,11 @@ export const EventForm = ({
   // Validation for series mode
   const seriesError = mode === 'series' && seriesDates.length < 2
 
+  // Filter categories: only show active categories when creating, all when editing
+  const availableCategories = isEditMode
+    ? categories
+    : categories.filter(c => c.is_active)
+
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
@@ -475,7 +480,7 @@ export const EventForm = ({
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {categories.map(category => (
+                  {availableCategories.map(category => (
                     <SelectItem key={category.guid} value={category.guid}>
                       <span className="flex items-center gap-2">
                         {category.color && (
@@ -485,6 +490,9 @@ export const EventForm = ({
                           />
                         )}
                         {category.name}
+                        {!category.is_active && (
+                          <span className="text-muted-foreground">(inactive)</span>
+                        )}
                       </span>
                     </SelectItem>
                   ))}


### PR DESCRIPTION
## Summary
- Filter inactive categories from the category dropdown when creating new Events
- Align EventForm behavior with existing LocationForm, OrganizerForm, and PerformerForm
- Show "(inactive)" label for inactive categories when editing existing events

## Test plan
- [x] Create a new event and verify inactive categories are not shown in the dropdown
- [x] Edit an existing event and verify all categories (including inactive) are shown with "(inactive)" label
- [x] Verify LocationForm, OrganizerForm, PerformerForm still work correctly

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)