### PR TITLE
feat: Serve SPA and APIs from same FastAPI server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   backend-test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -46,6 +48,8 @@ jobs:
 
   backend-web-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
@@ -82,6 +86,8 @@ jobs:
 
   frontend-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -554,8 +554,13 @@ async def spa_catch_all(request: Request, full_path: str):
     # Check if the requested path is a static file that exists in dist root
     # This handles files like favicon.ico, robots.txt, etc.
     if full_path and "." in full_path.split("/")[-1]:
-        static_file_path = _spa_dist_path / full_path
-        if static_file_path.exists() and static_file_path.is_file():
-            return FileResponse(static_file_path)
+        # Security: Serve static files only from allowed filenames
+        # Use an allowlist of known static files to prevent path traversal
+        allowed_static_files = ["favicon.ico", "robots.txt", "manifest.json", "logo.png"]
+        filename = full_path.split("/")[-1] if "/" in full_path else full_path
+        if filename in allowed_static_files:
+            static_file = _spa_dist_path / filename
+            if static_file.exists() and static_file.is_file():
+                return FileResponse(static_file)
 
     return await serve_spa(request)


### PR DESCRIPTION
Configure FastAPI to serve both the REST API and React SPA from the same port, enabling single-port HTTPS deployment.

Changes:
- Add static file serving for frontend/dist/assets/ at /assets
- Add catch-all route for SPA client-side routing
- Update CSP headers: restrictive for API, permissive for SPA pages
- Serve index.html for all non-API routes (React Router handles routing)
- Return helpful error message if frontend not built