### PR TITLE
security: Configurable rate limit storage and GeoIP geofencing middleware

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -88,6 +88,16 @@ JWT_SECRET_KEY=
 # Security Settings
 # =============================================================================
 
+# Rate limiting storage backend (default: memory://)
+# "memory://" is fine for single-process deployments (uvicorn with 1 worker).
+# For multi-worker (uvicorn --workers N) or multi-instance deployments,
+# use a shared backend so rate limits are enforced globally:
+#   redis://localhost:6379        - Redis (recommended)
+#   memcached://localhost:11211   - Memcached
+#   redis+sentinel://host:26379   - Redis Sentinel (HA)
+# NOTE: Redis backend requires: pip install redis
+# RATE_LIMIT_STORAGE_URI=memory://
+
 # Require agent attestation for all agent API requests
 # Must be set on Production servers
 # REQUIRE_AGENT_ATTESTATION=true
@@ -95,6 +105,27 @@ JWT_SECRET_KEY=
 # Super admin email hashes (comma-separated SHA-256 hex digests)
 # Generate a hash: python -c "import hashlib; print(hashlib.sha256('admin@example.com'.lower().encode()).hexdigest())"
 # SHUSAI_SUPER_ADMIN_HASHES=hash1,hash2
+
+# =============================================================================
+# GeoIP Geofencing (Optional)
+# =============================================================================
+
+# Country-based access control using MaxMind GeoLite2-Country database.
+# Download from: https://dev.maxmind.com/geoip/geolite2-free-geolocation-data
+# Requires a free MaxMind account.
+#
+# When enabled, only requests from listed countries are allowed.
+# Private/loopback IPs always bypass geofencing. /health is always exempt.
+
+# Path to MaxMind GeoLite2-Country .mmdb database file (empty = disabled)
+# SHUSAI_GEOIP_DB_PATH=/opt/geoip/GeoLite2-Country.mmdb
+
+# Comma-separated ISO 3166-1 alpha-2 country codes
+# WARNING: An empty list with a configured DB path will block ALL non-private requests
+# SHUSAI_GEOIP_ALLOWED_COUNTRIES=US,CA
+
+# If true, allow requests when GeoIP lookup returns no country (default: false = block unknown)
+# SHUSAI_GEOIP_FAIL_OPEN=false
 
 # =============================================================================
 # Job Queue Configuration

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -46,6 +46,10 @@ pywebpush>=2.0.0  # Web Push protocol with VAPID authentication
 
 # Security
 slowapi>=0.1.9  # Rate limiting middleware
+# For Redis-backed rate limiting (multi-worker deployments), install:
+#   pip install redis
+# Then set RATE_LIMIT_STORAGE_URI=redis://localhost:6379
+geoip2>=4.8.0  # GeoIP geofencing (requires MaxMind GeoLite2-Country database)
 
 # Authentication (OAuth 2.0 + PKCE)
 authlib>=1.6.0  # OAuth 2.0/OpenID Connect client

--- a/backend/src/api/auth.py
+++ b/backend/src/api/auth.py
@@ -22,10 +22,9 @@ from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from backend.src.db.database import get_db
+from backend.src.main import limiter
 from backend.src.middleware.auth import require_super_admin, TenantContext
 from backend.src.services.auth_service import AuthService
 from backend.src.services.exceptions import ValidationError
@@ -33,9 +32,6 @@ from backend.src.utils.logging_config import get_logger
 
 
 logger = get_logger("api")
-
-# Rate limiter for auth endpoints
-limiter = Limiter(key_func=get_remote_address)
 
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])

--- a/backend/src/api/tools.py
+++ b/backend/src/api/tools.py
@@ -21,11 +21,10 @@ from fastapi import (
     APIRouter, Depends, HTTPException, Query, Request, WebSocket,
     WebSocketDisconnect, status
 )
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
 
 from backend.src.db.database import get_db
+from backend.src.main import limiter
 from backend.src.middleware.tenant import TenantContext, get_tenant_context
 from backend.src.schemas.tools import (
     ToolType, ToolMode, JobStatus, ToolRunRequest, JobResponse,
@@ -47,9 +46,6 @@ router = APIRouter(
     prefix="/tools",
     tags=["Tools"],
 )
-
-# Rate limiter instance - shared from main app
-limiter = Limiter(key_func=get_remote_address)
 
 
 # ============================================================================

--- a/backend/src/middleware/geofence.py
+++ b/backend/src/middleware/geofence.py
@@ -1,0 +1,166 @@
+"""
+GeoIP-based geofencing middleware for ShutterSense.
+
+Restricts API access to requests originating from configured allowed countries
+using MaxMind GeoLite2-Country database lookups.
+
+When enabled:
+- Requests from allowed countries proceed normally
+- Requests from disallowed countries receive 403 Forbidden
+- Private/loopback IPs always pass (development, internal services)
+- /health endpoint is always exempt (health probes)
+- Unknown IPs are blocked by default (configurable via SHUSAI_GEOIP_FAIL_OPEN)
+
+When disabled (no SHUSAI_GEOIP_DB_PATH configured):
+- Middleware is not registered; zero runtime impact
+"""
+
+import ipaddress
+from typing import Set
+
+import geoip2.database
+import geoip2.errors
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from backend.src.utils.logging_config import get_logger
+
+logger = get_logger("api")
+
+# Paths exempt from geofencing (health probes must always work)
+EXEMPT_PATHS: Set[str] = {"/health"}
+
+
+class GeoFenceMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware that blocks requests from countries not in the allowlist.
+
+    Uses MaxMind GeoLite2-Country database for IP-to-country resolution.
+    Private/loopback IPs are always allowed through.
+
+    Args:
+        app: ASGI application
+        reader: Opened geoip2.database.Reader instance
+        allowed_countries: Set of uppercase ISO 3166-1 alpha-2 country codes
+        fail_open: If True, allow requests when GeoIP lookup returns no country
+    """
+
+    def __init__(
+        self,
+        app,
+        reader: geoip2.database.Reader,
+        allowed_countries: Set[str],
+        fail_open: bool = False,
+    ):
+        super().__init__(app)
+        self.reader = reader
+        self.allowed_countries = allowed_countries
+        self.fail_open = fail_open
+
+    async def dispatch(self, request: Request, call_next):
+        # Skip WebSocket connections
+        if request.scope.get("type") == "websocket":
+            return await call_next(request)
+
+        # Exempt paths (health probes)
+        if request.url.path in EXEMPT_PATHS:
+            return await call_next(request)
+
+        # Extract client IP
+        client_ip = self._get_client_ip(request)
+
+        # Allow private/loopback IPs (development, internal services)
+        if self._is_private_ip(client_ip):
+            return await call_next(request)
+
+        # GeoIP lookup
+        country_code = self._lookup_country(client_ip)
+
+        if country_code is None:
+            if self.fail_open:
+                return await call_next(request)
+            logger.warning(
+                "GeoFence: Blocked request from unknown country (IP: %s, path: %s)",
+                client_ip,
+                request.url.path,
+            )
+            return self._forbidden_response()
+
+        # Check against allowlist
+        if country_code in self.allowed_countries:
+            return await call_next(request)
+
+        logger.warning(
+            "GeoFence: Blocked request from %s (IP: %s, path: %s)",
+            country_code,
+            client_ip,
+            request.url.path,
+        )
+        return self._forbidden_response()
+
+    @staticmethod
+    def _get_client_ip(request: Request) -> str:
+        """
+        Extract client IP from the request.
+
+        Uses request.client.host which is resolved by Uvicorn's
+        ProxyHeadersMiddleware when --proxy-headers and
+        --forwarded-allow-ips are configured.
+
+        Args:
+            request: Starlette Request object
+
+        Returns:
+            Client IP address string
+        """
+        if request.client:
+            return request.client.host
+        return "0.0.0.0"
+
+    @staticmethod
+    def _is_private_ip(ip_str: str) -> bool:
+        """
+        Check if an IP address is private, loopback, or link-local.
+
+        Handles both IPv4 and IPv6 addresses.
+
+        Args:
+            ip_str: IP address string
+
+        Returns:
+            True if the IP is non-routable
+        """
+        try:
+            addr = ipaddress.ip_address(ip_str)
+            return addr.is_private or addr.is_loopback or addr.is_link_local
+        except ValueError:
+            return False
+
+    def _lookup_country(self, ip_str: str) -> str | None:
+        """
+        Look up the country code for an IP address using the GeoIP database.
+
+        Args:
+            ip_str: IP address string
+
+        Returns:
+            ISO 3166-1 alpha-2 country code (uppercase), or None if unknown
+        """
+        try:
+            response = self.reader.country(ip_str)
+            country = response.country.iso_code
+            return country.upper() if country else None
+        except geoip2.errors.AddressNotFoundError:
+            return None
+        except Exception as e:
+            logger.error("GeoFence: GeoIP lookup error for %s: %s", ip_str, e)
+            return None
+
+    @staticmethod
+    def _forbidden_response() -> JSONResponse:
+        """Return a 403 response for blocked requests."""
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "Access denied based on geographic restrictions"},
+        )

--- a/backend/src/services/notification_service.py
+++ b/backend/src/services/notification_service.py
@@ -536,7 +536,12 @@ class NotificationService:
         """
         try:
             from pywebpush import webpush, WebPushException
+        except ImportError as e:
+            raise PushDeliveryError(
+                "pywebpush is not installed. Install with: pip install pywebpush"
+            ) from e
 
+        try:
             subscription_info = {
                 "endpoint": subscription.endpoint,
                 "keys": {


### PR DESCRIPTION
## Summary

- **Configurable rate limit storage**: Upgrade SlowAPI from hardcoded in-memory storage to a configurable backend via `RATE_LIMIT_STORAGE_URI` (default: `memory://`). Supports Redis, Memcached, and Redis Sentinel for multi-worker/multi-instance deployments. Consolidate three duplicate `Limiter` instances (main.py, auth.py, tools.py) into a single shared instance.

- **GeoIP geofencing middleware**: Add optional country-based access control using MaxMind GeoLite2-Country `.mmdb` database. Operates in allowlist mode with fail-closed default for unknown IPs. Private/loopback IPs and `/health` are always exempt. Entirely optional — no config means no middleware registered and zero overhead.

- **Fix pywebpush import bug**: Fix `UnboundLocalError` in `notification_service.py._send_push()` where `WebPushException` was imported inside a `try` block but referenced in the `except` clause. Separated import into its own `try/except ImportError` that gracefully converts to `PushDeliveryError`.

### Files changed

| File | Change |
|------|--------|
| `backend/src/middleware/geofence.py` | **New** — GeoFenceMiddleware with allowlist, private IP bypass, /health exemption |
| `backend/src/config/settings.py` | Add `rate_limit_storage_uri` + 3 GeoIP settings + properties |
| `backend/src/main.py` | Configurable limiter storage, geofence middleware registration, lifespan logging/cleanup |
| `backend/src/api/auth.py` | Remove duplicate Limiter, import shared instance from main |
| `backend/src/api/tools.py` | Remove duplicate Limiter, import shared instance from main |
| `backend/src/services/notification_service.py` | Fix pywebpush lazy import scoping bug |
| `backend/requirements.txt` | Add `geoip2>=4.8.0`, Redis install note |
| `backend/.env.example` | Add `RATE_LIMIT_STORAGE_URI` and GeoIP env vars |
| `backend/tests/unit/test_security.py` | Add 16 tests (3 rate limit settings, 6 geofence settings, 7 geofence middleware) |
| `docs/installation.md` | Add Rate Limiting Storage + GeoIP Geofencing sections, env var table |
| `docs/security.md` | Add rate limit storage, geofencing, reverse proxy `--forwarded-allow-ips`, deployment checklist |

## Test plan

- [x] All 30 security tests pass (`backend/tests/unit/test_security.py`)
- [x] All 17 notification tests pass (previously 1 failing, now fixed)
- [x] Full backend suite: 1893 tests — 1882 passed, 11 skipped, 0 failures
- [ ] Manual: Verify rate limiting works with `RATE_LIMIT_STORAGE_URI=redis://...` on multi-worker setup
- [ ] Manual: Verify geofencing with a real GeoLite2-Country `.mmdb` database file
- [ ] Manual: Confirm geofencing disabled when `SHUSAI_GEOIP_DB_PATH` is not set (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable rate limiting with support for external storage backends (Redis, Memcached, Redis Sentinel).
  * Optional country-based access control via GeoIP geofencing.

* **Documentation**
  * Setup and env var guides for rate limiting and GeoIP features; updated environment variable reference.

* **Tests**
  * Expanded tests covering rate limiting and GeoIP behavior.

* **Bug Fixes**
  * Improved error handling when push notification dependency is missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->