### PR TITLE
Improve principal stats on Dashboard view

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import { Link } from 'react-router-dom'
 import {
   FolderOpen,
   FileImage,
+  HardDrive,
   BarChart3,
   Activity,
   Clock,
@@ -388,12 +389,12 @@ export default function DashboardPage() {
     const statsArray: Array<{ label: string; value: string | number }> = []
 
     if (collectionStats) {
-      statsArray.push({ label: 'Collections', value: collectionStats.total_collections })
-      statsArray.push({ label: 'Files', value: collectionStats.file_count.toLocaleString() })
+      statsArray.push({ label: 'Storage', value: collectionStats.storage_used_formatted })
+      statsArray.push({ label: 'Images', value: collectionStats.image_count.toLocaleString() })
     }
 
-    if (resultStats) {
-      statsArray.push({ label: 'Results', value: resultStats.total_results })
+    if (queueStatus) {
+      statsArray.push({ label: 'Scheduled', value: queueStatus.scheduled_count })
     }
 
     if (queueStatus && queueStatus.running_count > 0) {
@@ -402,23 +403,23 @@ export default function DashboardPage() {
 
     setStats(statsArray)
     return () => setStats([])
-  }, [collectionStats, resultStats, queueStatus, setStats])
+  }, [collectionStats, queueStatus, setStats])
 
   return (
     <div className="flex flex-col gap-6">
       {/* KPI Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <KpiCard
-          title="Collections"
-          value={collectionStats?.total_collections ?? 0}
-          subtitle={collectionStats ? `${collectionStats.storage_used_formatted} storage` : undefined}
-          icon={FolderOpen}
+          title="Total Storage"
+          value={collectionStats?.storage_used_formatted ?? '0 B'}
+          subtitle={collectionStats ? `${collectionStats.total_collections} collection${collectionStats.total_collections !== 1 ? 's' : ''}` : undefined}
+          icon={HardDrive}
           loading={collectionsLoading}
         />
         <KpiCard
-          title="Total Files"
-          value={collectionStats?.file_count.toLocaleString() ?? '0'}
-          subtitle={collectionStats ? `${collectionStats.image_count.toLocaleString()} images` : undefined}
+          title="Images"
+          value={collectionStats?.image_count.toLocaleString() ?? '0'}
+          subtitle={collectionStats ? `${collectionStats.file_count.toLocaleString()} files total` : undefined}
           icon={FileImage}
           loading={collectionsLoading}
         />

--- a/frontend/tests/components/DashboardPage.test.tsx
+++ b/frontend/tests/components/DashboardPage.test.tsx
@@ -206,14 +206,14 @@ describe('DashboardPage', () => {
   // Header Stats
   // --------------------------------------------------------------------------
 
-  it('sets header stats with collection, result, and queue data', () => {
+  it('sets header stats with storage, images, scheduled, and running data', () => {
     render(<DashboardPage />)
 
     expect(mockSetStats).toHaveBeenCalledWith(
       expect.arrayContaining([
-        expect.objectContaining({ label: 'Collections', value: 12 }),
-        expect.objectContaining({ label: 'Files' }),
-        expect.objectContaining({ label: 'Results', value: 42 }),
+        expect.objectContaining({ label: 'Storage', value: '4.66 GB' }),
+        expect.objectContaining({ label: 'Images' }),
+        expect.objectContaining({ label: 'Scheduled', value: 2 }),
         expect.objectContaining({ label: 'Running', value: 3 }),
       ])
     )
@@ -250,16 +250,15 @@ describe('DashboardPage', () => {
   it('renders all four KPI cards with data', () => {
     render(<DashboardPage />)
 
-    // Collections KPI card (also exists in Quick Links)
-    expect(screen.getAllByText('Collections').length).toBeGreaterThanOrEqual(1)
-    // '12' also appears in trend data points (photo_pairing: 12)
-    expect(screen.getAllByText('12').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText('4.66 GB storage')).toBeInTheDocument()
+    // Storage KPI card
+    expect(screen.getByText('Total Storage')).toBeInTheDocument()
+    expect(screen.getByText('4.66 GB')).toBeInTheDocument()
+    expect(screen.getByText('12 collections')).toBeInTheDocument()
 
-    // Files card
-    expect(screen.getByText('Total Files')).toBeInTheDocument()
-    expect(screen.getByText('15,000')).toBeInTheDocument()
-    expect(screen.getByText('12,500 images')).toBeInTheDocument()
+    // Images card
+    expect(screen.getByText('Images')).toBeInTheDocument()
+    expect(screen.getByText('12,500')).toBeInTheDocument()
+    expect(screen.getByText('15,000 files total')).toBeInTheDocument()
 
     // Results card
     expect(screen.getByText('Analysis Results')).toBeInTheDocument()
@@ -410,8 +409,8 @@ describe('DashboardPage', () => {
 
     render(<DashboardPage />)
 
-    // "Collections" appears in both KPI card and Quick Links
-    expect(screen.getAllByText('Collections').length).toBeGreaterThanOrEqual(1)
+    // "Total Storage" KPI card title renders even during loading
+    expect(screen.getByText('Total Storage')).toBeInTheDocument()
     // The loading state renders a pulse div instead of a value
   })
 
@@ -454,7 +453,7 @@ describe('DashboardPage', () => {
 
     render(<DashboardPage />)
 
-    expect(screen.getByText('0 B storage')).toBeInTheDocument()
+    expect(screen.getByText('0 collections')).toBeInTheDocument()
     expect(screen.getByText('0 completed, 0 failed')).toBeInTheDocument()
   })
 
@@ -465,7 +464,7 @@ describe('DashboardPage', () => {
     render(<DashboardPage />)
 
     // Should render with fallback values
-    expect(screen.getAllByText('Collections').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText('Total Files')).toBeInTheDocument()
+    expect(screen.getByText('Total Storage')).toBeInTheDocument()
+    expect(screen.getByText('Images')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- **Storage over collections**: Header stat and KPI card now show total storage as the primary metric, with collection count as a subtitle
- **Images over files**: Header stat and KPI card now show image count as the primary metric, with total file count as a subtitle
- **Scheduled jobs over results**: Header stat now shows scheduled job count (forward-looking) instead of total result count (backward-looking)

Closes #140

## Test plan
- [x] All 20 DashboardPage tests pass with updated assertions
- [ ] Verify header stats show Storage, Images, Scheduled (and Running when > 0)
- [ ] Verify KPI cards display Total Storage (with collection count subtitle) and Images (with file count subtitle)
- [ ] Verify zero-data and loading states render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned dashboard KPI display: now shows Total Storage, Images count, and Scheduled items instead of Collections, Files, and Results.

* **Tests**
  * Updated dashboard test coverage to reflect new metrics and labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->