### PR TITLE
Update API documentation endpoints to use /api-docs and /api-redoc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ All components use the same version from `version.py`:
    - `shuttersense-agent --version`
 
 2. **Backend API**:
-   - FastAPI app version (shown in `/docs`)
+   - FastAPI app version (shown in `/api-docs`)
    - `/api/version` endpoint
    - `/health` endpoint
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -261,8 +261,8 @@ uvicorn src.main:app --reload --host 0.0.0.0 --port 8000
 
 The API will be available at:
 - **API**: [http://localhost:8000/api](http://localhost:8000/api)
-- **OpenAPI docs (Swagger UI)**: [http://localhost:8000/docs](http://localhost:8000/docs)
-- **ReDoc**: [http://localhost:8000/redoc](http://localhost:8000/redoc)
+- **OpenAPI docs (Swagger UI)**: [http://localhost:8000/api-docs](http://localhost:8000/api-docs)
+- **ReDoc**: [http://localhost:8000/api-redoc](http://localhost:8000/api-redoc)
 - **OpenAPI JSON**: [http://localhost:8000/openapi.json](http://localhost:8000/openapi.json)
 - **Health check**: [http://localhost:8000/health](http://localhost:8000/health)
 - **Version**: [http://localhost:8000/api/version](http://localhost:8000/api/version)
@@ -673,8 +673,8 @@ source backend/.env  # Or use python-dotenv (automatically loaded by pydantic-se
 
 ### Interactive Documentation
 
-- **Swagger UI**: [http://localhost:8000/docs](http://localhost:8000/docs) (with Bearer token authorization)
-- **ReDoc**: [http://localhost:8000/redoc](http://localhost:8000/redoc)
+- **Swagger UI**: [http://localhost:8000/api-docs](http://localhost:8000/api-docs) (with Bearer token authorization)
+- **ReDoc**: [http://localhost:8000/api-redoc](http://localhost:8000/api-redoc)
 - **OpenAPI JSON**: [http://localhost:8000/openapi.json](http://localhost:8000/openapi.json)
 
 ### Authentication
@@ -925,7 +925,7 @@ mypy backend/src
 6. **Create API endpoints** in `src/api/`
 7. **Write tests** in `tests/unit/` and `tests/integration/`
 8. **Run tests with coverage**: `pytest tests/ --cov=backend.src`
-9. **Review OpenAPI docs**: http://localhost:8000/docs
+9. **Review OpenAPI docs**: http://localhost:8000/api-docs
 
 ### Adding a New Storage Adapter
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -101,7 +101,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Content-Type-Options"] = "nosniff"
 
         # Prevent clickjacking (allow for docs pages)
-        if request.url.path not in ["/docs", "/redoc", "/openapi.json"]:
+        if request.url.path not in ["/api-docs", "/api-redoc", "/openapi.json"]:
             response.headers["X-Frame-Options"] = "DENY"
 
         # Enable XSS filter (legacy, but still useful for older browsers)
@@ -113,7 +113,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # Content Security Policy
         # Different CSP for API vs SPA pages
         path = request.url.path
-        if path in ["/docs", "/redoc", "/openapi.json"]:
+        if path in ["/api-docs", "/api-redoc", "/openapi.json"]:
             # Skip restrictive CSP for documentation pages (Swagger UI needs external resources)
             pass
         elif path.startswith("/api/") or path == "/health":
@@ -812,7 +812,7 @@ def custom_openapi():
     Generate custom OpenAPI schema with Bearer token authentication.
 
     This adds the HTTPBearer security scheme to the OpenAPI spec, enabling
-    the "Authorize" button in Swagger UI (/docs) and ReDoc (/redoc).
+    the "Authorize" button in Swagger UI (/api-docs) and ReDoc (/api-redoc).
 
     Users can enter their API token to test authenticated endpoints.
 
@@ -874,7 +874,7 @@ app.openapi = custom_openapi
 # ============================================================================
 # Custom Documentation Endpoints with Favicon
 # ============================================================================
-@app.get("/docs", include_in_schema=False)
+@app.get("/api-docs", include_in_schema=False)
 async def custom_swagger_ui_html():
     """Serve Swagger UI with custom favicon."""
     return get_swagger_ui_html(
@@ -884,7 +884,7 @@ async def custom_swagger_ui_html():
     )
 
 
-@app.get("/redoc", include_in_schema=False)
+@app.get("/api-redoc", include_in_schema=False)
 async def custom_redoc_html():
     """Serve ReDoc with custom favicon."""
     return get_redoc_html(

--- a/backend/tests/unit/test_security.py
+++ b/backend/tests/unit/test_security.py
@@ -65,7 +65,7 @@ class TestRateLimiting:
         assert response.status_code == 200
 
         # The app should start successfully with rate limiter configured
-        response = test_client.get("/docs")
+        response = test_client.get("/api-docs")
         assert response.status_code == 200
 
     def test_request_size_limit_rejection(self, test_client):

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,8 +6,8 @@ The ShutterSense backend exposes a RESTful API with 140+ endpoints. This documen
 
 When the server is running, interactive API documentation is available at:
 
-- **Swagger UI**: `http://localhost:8000/docs`
-- **ReDoc**: `http://localhost:8000/redoc`
+- **Swagger UI**: `http://localhost:8000/api-docs`
+- **ReDoc**: `http://localhost:8000/api-redoc`
 - **OpenAPI JSON**: `http://localhost:8000/openapi.json`
 
 ## API Conventions

--- a/docs/api/inventory.md
+++ b/docs/api/inventory.md
@@ -336,4 +336,4 @@ For agent-side credential connectors, the agent reports results via:
 - `POST /api/agent/v1/jobs/{job_guid}/inventory/file-info` - Phase B results
 - `POST /api/agent/v1/jobs/{job_guid}/inventory/delta` - Phase C results
 
-See the OpenAPI documentation at `/docs` for full schema details.
+See the OpenAPI documentation at `/api-docs` for full schema details.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,7 +221,7 @@ In production, FastAPI serves both the API and the React SPA from the same serve
                     │                          │
   /api/*     ───►   │  API Routes (JSON)       │
   /health    ───►   │  Health Check            │
-  /docs      ───►   │  OpenAPI Documentation   │
+  /api-docs  ───►   │  OpenAPI Documentation   │
   /assets/*  ───►   │  Static Assets (dist/)   │
   /*         ───►   │  index.html (SPA)        │
                     └──────────────────────────┘

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ python3 web_server.py --reload
 
 The API will be available at:
 - API: http://localhost:8000/api
-- OpenAPI docs: http://localhost:8000/docs
+- OpenAPI docs: http://localhost:8000/api-docs
 - Health check: http://localhost:8000/health
 
 ### 3. Frontend Setup

--- a/web_server.py
+++ b/web_server.py
@@ -209,7 +209,7 @@ def main() -> None:
     print(f"Host: {args.host}")
     print(f"Port: {args.port}")
     print(f"Auto-reload: {'enabled' if args.reload else 'disabled'}")
-    print(f"\nAPI documentation: http://{args.host}:{args.port}/docs")
+    print(f"\nAPI documentation: http://{args.host}:{args.port}/api-docs")
     print(f"Health check: http://{args.host}:{args.port}/health")
     print("\nPress CTRL+C to stop the server\n")
 


### PR DESCRIPTION
## Summary
This PR updates all API documentation endpoints from the default FastAPI paths (`/docs`, `/redoc`) to namespaced paths (`/api-docs`, `/api-redoc`) to better organize the API surface and avoid potential conflicts with frontend routing.

## Changes Made
- **Backend routes**: Updated FastAPI endpoint decorators in `backend/src/main.py` to serve Swagger UI at `/api-docs` and ReDoc at `/api-redoc`
- **Security middleware**: Updated X-Frame-Options and CSP header logic to recognize the new documentation paths
- **Documentation**: Updated all references across documentation files (README.md, installation.md, architecture.md, inventory.md, api/README.md)
- **Tests**: Updated test assertions to use the new `/api-docs` endpoint
- **CLI output**: Updated the web server startup message to display the correct documentation URL

## Implementation Details
- The custom OpenAPI endpoint registration was updated to use the new paths while maintaining the same functionality
- All security headers and CSP policies were adjusted to properly handle the renamed documentation endpoints
- The change is backward compatible in terms of functionality - only the URL paths have changed
- Documentation comments were updated to reflect the new endpoint names

https://claude.ai/code/session_01LyHe3yNuPNEacxcUaXdzhm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized API documentation endpoints: Swagger UI now accessible at `/api-docs` (previously `/docs`) and ReDoc at `/api-redoc` (previously `/redoc`). Updated all references across documentation and internal configurations to reflect the new endpoint locations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->