### PR TITLE
fix: Prevent WebSocket endpoints from exhausting DB connection pool

### DIFF
--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -50,6 +50,7 @@ else:
         max_overflow=10,       # Additional connections beyond pool_size
         pool_pre_ping=True,    # Verify connections before checkout
         pool_recycle=3600,     # Recycle connections after 1 hour
+        pool_timeout=5,        # Timeout waiting for connection (keeps CTRL+C responsive)
         echo=False,            # Set to True for SQL debugging
         future=True            # Use SQLAlchemy 2.0 style
     )

--- a/frontend/src/contracts/api/tools-api.ts
+++ b/frontend/src/contracts/api/tools-api.ts
@@ -182,10 +182,15 @@ export interface WebSocketCloseMessage {
   reason: string
 }
 
+export interface WebSocketReconnectMessage {
+  type: 'reconnect'
+}
+
 export type WebSocketMessage =
   | WebSocketProgressMessage
   | WebSocketStatusMessage
   | WebSocketCloseMessage
+  | WebSocketReconnectMessage
 
 // ============================================================================
 // API Endpoint Definitions (OpenAPI-style documentation)


### PR DESCRIPTION
## Summary

- **Root cause**: WebSocket endpoints used `Depends(get_db)` which held DB connections for their entire lifetime (hours), exhausting the 30-connection pool
- **Fix**: WebSocket endpoints now use short-lived sessions only for authentication, then release them immediately
- **Added**: 30-minute connection lifecycle with graceful reconnect to prevent stale connections
- **Added**: 5-second pool timeout for faster failure and CTRL+C responsiveness

## Test plan

- [ ] Start backend server, open multiple browser tabs with the application
- [ ] Verify WebSocket connections work normally (job updates, agent pool status)
- [ ] Wait 30+ minutes and verify connections automatically reconnect (check browser console for `Server requested reconnect` logs)
- [ ] Verify CTRL+C terminates the server promptly (within ~5 seconds)
- [ ] Stress test: open 30+ tabs and verify server remains responsive

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket connections now enforce a 30-minute maximum lifetime with automatic reconnection, preventing long-lived stale connections.
  * Server-initiated reconnection requests are processed immediately without backoff delays, improving connection reliability.
  * Optimized database connection pooling and timeout handling for WebSocket endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->