### PR TITLE
docs: Improve API documentation deployment guide and fix favicon

### DIFF
--- a/backend/src/api/public_docs.py
+++ b/backend/src/api/public_docs.py
@@ -234,7 +234,7 @@ async def public_swagger_ui():
     return get_swagger_ui_html(
         openapi_url="/public/api/openapi.json",
         title="ShutterSense.ai Public API - Swagger UI",
-        swagger_favicon_url="/favicon.svg",
+        swagger_favicon_url="https://app.shuttersense.ai/favicon.svg",
     )
 
 
@@ -244,5 +244,5 @@ async def public_redoc():
     return get_redoc_html(
         openapi_url="/public/api/openapi.json",
         title="ShutterSense.ai Public API - ReDoc",
-        redoc_favicon_url="/favicon.svg",
+        redoc_favicon_url="https://app.shuttersense.ai/favicon.svg",
     )


### PR DESCRIPTION
## Summary

- Restructure SSL certificate section to come after nginx configuration (certbot --nginx requires server blocks to exist)
- Use `certbot --nginx --force-renewal` instead of standalone mode for proper auto-renewal support
- Add `/public/api/openapi.json` nginx location block for Swagger UI spec fetching
- Enhance `docs.shuttersense.ai` landing page with ShutterSense branding, favicon, and logo
- Fix favicon in public Swagger UI and ReDoc pages using absolute URLs

## Test plan

- [ ] Verify `docs.shuttersense.ai` landing page displays correctly with favicon and logo
- [ ] Verify `docs.shuttersense.ai/api/docs` (Swagger UI) shows favicon
- [ ] Verify `docs.shuttersense.ai/api/redoc` shows favicon
- [ ] Verify Swagger UI can fetch `/public/api/openapi.json` without 404
- [ ] Verify `certbot renew --dry-run` succeeds after following the updated guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public API documentation endpoints now available for access
  * Documentation portal redesigned with improved card-based layout

* **Documentation**
  * Deployment documentation restructured for clarity on hosting configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->