### PR TITLE
Harden path containment check in download service

### DIFF
--- a/backend/src/services/download_service.py
+++ b/backend/src/services/download_service.py
@@ -147,7 +147,9 @@ def resolve_binary_path(
 
     # Verify the resolved path is within the distribution directory
     # This prevents path traversal attacks (e.g., version="../../etc")
-    if not str(file_path).startswith(str(dist_path)):
+    # Use os.sep suffix to prevent prefix-matching sibling directories
+    # (e.g., dist_path="/srv/dist" must not match "/srv/dist_evil/file")
+    if not str(file_path).startswith(str(dist_path) + "/"):
         return None, "Invalid file path"
 
     # Check file exists


### PR DESCRIPTION
## Summary
- Fixes a subtle edge case in `resolve_binary_path()` where the `startswith` containment check could match sibling directories (e.g., `dist_path="/srv/dist"` would match `/srv/dist_evil/file`)
- Appends a trailing `/` to the prefix so the check is self-sufficient, independent of upstream input validation
- Addresses CodeQL `py/path-injection` alerts [#43](https://github.com/fabrice-guiot/shuttersense/security/code-scanning/43) and [#44](https://github.com/fabrice-guiot/shuttersense/security/code-scanning/44) (false positives — inputs are already validated by regex + separator checks, but this hardens the final guard)

## Test plan
- [x] All 32 existing tests in `test_download_service.py` pass with no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)