### PR TITLE
Fix event logistics pipeline for series and individual events

### DIFF
--- a/backend/src/api/events.py
+++ b/backend/src/api/events.py
@@ -478,6 +478,12 @@ async def create_event_series(
             ticket_required=series_data.ticket_required,
             timeoff_required=series_data.timeoff_required,
             travel_required=series_data.travel_required,
+            ticket_status=series_data.ticket_status.value if series_data.ticket_status else None,
+            ticket_purchase_date=series_data.ticket_purchase_date,
+            timeoff_status=series_data.timeoff_status.value if series_data.timeoff_status else None,
+            timeoff_booking_date=series_data.timeoff_booking_date,
+            travel_status=series_data.travel_status.value if series_data.travel_status else None,
+            travel_booking_date=series_data.travel_booking_date,
             deadline_date=series_data.deadline_date,
             deadline_time=series_data.deadline_time,
         )

--- a/backend/src/schemas/event.py
+++ b/backend/src/schemas/event.py
@@ -187,9 +187,18 @@ class EventSeriesCreate(BaseModel):
     is_all_day: bool = Field(default=False)
     input_timezone: Optional[str] = Field(default=None, max_length=64)
 
+    # Logistics requirements (boolean flags)
     ticket_required: bool = Field(default=False)
     timeoff_required: bool = Field(default=False)
     travel_required: bool = Field(default=False)
+
+    # Logistics status and dates (applied to all events in series)
+    ticket_status: Optional[TicketStatus] = Field(default=None)
+    ticket_purchase_date: Optional[date] = Field(default=None)
+    timeoff_status: Optional[TimeoffStatus] = Field(default=None)
+    timeoff_booking_date: Optional[date] = Field(default=None)
+    travel_status: Optional[TravelStatus] = Field(default=None)
+    travel_booking_date: Optional[date] = Field(default=None)
 
     # Deadline for deliverables (creates a deadline entry in the calendar)
     deadline_date: Optional[date] = Field(

--- a/backend/tests/integration/test_logistics_inheritance.py
+++ b/backend/tests/integration/test_logistics_inheritance.py
@@ -1,0 +1,217 @@
+"""
+Test to verify series event logistics inheritance.
+
+Issue: Logistics fields (ticket_required, timeoff_required, travel_required) were not
+properly inherited from series when viewing/editing series events.
+
+Fix: build_event_detail_response now preserves the inherited values from
+build_event_response instead of overwriting them with raw NULL values.
+"""
+import pytest
+from datetime import date
+
+from backend.src.models import Category, Event, EventSeries
+
+
+class TestSeriesLogisticsInheritance:
+    """Test series event logistics inheritance after fix."""
+
+    @pytest.fixture
+    def test_category(self, test_db_session, test_team):
+        """Create a test category."""
+        category = Category(
+            name="Test Logistics Category",
+            icon="plane",
+            color="#3B82F6",
+            is_active=True,
+            display_order=0,
+            team_id=test_team.id,
+        )
+        test_db_session.add(category)
+        test_db_session.commit()
+        test_db_session.refresh(category)
+        return category
+
+    def test_series_event_logistics_inheritance(self, test_client, test_category):
+        """
+        Verify that:
+        1. Series events inherit logistics from series (not NULL)
+        2. Event detail response shows inherited values
+        3. After editing, event stores explicit value
+        """
+        # Create a series with ticket_required=True
+        response = test_client.post(
+            "/api/events/series",
+            json={
+                "title": "Test Series",
+                "category_guid": test_category.guid,
+                "event_dates": ["2026-09-10", "2026-09-11"],
+                "ticket_required": True,
+                "timeoff_required": True,
+                "travel_required": False,
+            },
+        )
+        assert response.status_code == 201
+        events = response.json()
+
+        # Get the first event's GUID
+        event_guid = events[0]["guid"]
+
+        # Fetch event detail - should show inherited values
+        detail = test_client.get(f"/api/events/{event_guid}")
+        assert detail.status_code == 200
+        data = detail.json()
+
+        # Verify inherited values are shown (not NULL)
+        assert data["ticket_required"] is True, "ticket_required should be inherited from series"
+        assert data["timeoff_required"] is True, "timeoff_required should be inherited from series"
+        assert data["travel_required"] is False, "travel_required should be inherited from series"
+
+        # Now update the event with explicit values
+        update_resp = test_client.patch(
+            f"/api/events/{event_guid}",
+            json={
+                "ticket_required": False,  # Override inherited value
+            },
+        )
+        assert update_resp.status_code == 200
+
+        # Verify update persisted
+        detail2 = test_client.get(f"/api/events/{event_guid}")
+        data2 = detail2.json()
+        assert data2["ticket_required"] is False, "ticket_required should be updated to False"
+        # Other fields still inherit
+        assert data2["timeoff_required"] is True
+
+    def test_standalone_event_logistics_not_affected(self, test_client, test_category):
+        """Verify standalone events still work correctly (no regression)."""
+        # Create standalone event with explicit logistics
+        response = test_client.post(
+            "/api/events",
+            json={
+                "title": "Standalone Event",
+                "category_guid": test_category.guid,
+                "event_date": "2026-10-15",
+                "ticket_required": True,
+                "timeoff_required": False,
+            },
+        )
+        assert response.status_code == 201
+        event_guid = response.json()["guid"]
+
+        # Verify detail shows correct values
+        detail = test_client.get(f"/api/events/{event_guid}")
+        data = detail.json()
+        assert data["ticket_required"] is True
+        assert data["timeoff_required"] is False
+
+        # Update and verify
+        update_resp = test_client.patch(
+            f"/api/events/{event_guid}",
+            json={"ticket_required": False},
+        )
+        assert update_resp.status_code == 200
+
+        detail2 = test_client.get(f"/api/events/{event_guid}")
+        assert detail2.json()["ticket_required"] is False
+
+    def test_series_with_fixture_events_inherit_logistics(
+        self, test_client, test_db_session, test_category, test_team
+    ):
+        """
+        Test with manually created series/events (like existing fixtures).
+        This verifies the inheritance works even when events are created
+        directly in DB without the API.
+        """
+        # Create series with logistics values
+        series = EventSeries(
+            title="Fixture Series",
+            category_id=test_category.id,
+            total_events=2,
+            ticket_required=True,
+            travel_required=True,
+            timeoff_required=False,
+            team_id=test_team.id,
+        )
+        test_db_session.add(series)
+        test_db_session.commit()
+        test_db_session.refresh(series)
+
+        # Create events with NULL logistics (inheritance pattern)
+        events = []
+        for i in range(2):
+            event = Event(
+                series_id=series.id,
+                sequence_number=i + 1,
+                event_date=date(2026, 11, 15 + i),
+                status="future",
+                attendance="planned",
+                team_id=test_team.id,
+                # Logistics explicitly NULL (inherit from series)
+                ticket_required=None,
+                timeoff_required=None,
+                travel_required=None,
+            )
+            test_db_session.add(event)
+            events.append(event)
+
+        test_db_session.commit()
+        for event in events:
+            test_db_session.refresh(event)
+
+        # Verify detail response shows inherited values
+        detail = test_client.get(f"/api/events/{events[0].guid}")
+        data = detail.json()
+
+        # These should be inherited from series, not NULL
+        assert data["ticket_required"] is True, "Should inherit ticket_required=True from series"
+        assert data["travel_required"] is True, "Should inherit travel_required=True from series"
+        assert data["timeoff_required"] is False, "Should inherit timeoff_required=False from series"
+
+    def test_series_logistics_status_and_dates_transmitted(self, test_client, test_category):
+        """
+        Verify that logistics status and date fields from series creation
+        are properly transmitted to individual events.
+        """
+        # Create a series with logistics status and dates
+        response = test_client.post(
+            "/api/events/series",
+            json={
+                "title": "Status Date Test Series",
+                "category_guid": test_category.guid,
+                "event_dates": ["2026-12-20", "2026-12-21"],
+                "ticket_required": True,
+                "ticket_status": "purchased",
+                "ticket_purchase_date": "2026-10-15",
+                "timeoff_required": True,
+                "timeoff_status": "approved",
+                "timeoff_booking_date": "2026-09-01",
+                "travel_required": True,
+                "travel_status": "booked",
+                "travel_booking_date": "2026-11-01",
+            },
+        )
+        assert response.status_code == 201
+        events = response.json()
+        assert len(events) == 2
+
+        # Check first event has all the status/date fields
+        event_guid = events[0]["guid"]
+        detail = test_client.get(f"/api/events/{event_guid}")
+        assert detail.status_code == 200
+        data = detail.json()
+
+        # Verify logistics requirements are inherited from series
+        assert data["ticket_required"] is True
+        assert data["timeoff_required"] is True
+        assert data["travel_required"] is True
+
+        # Verify logistics status fields are transmitted
+        assert data["ticket_status"] == "purchased", "ticket_status should be transmitted from series"
+        assert data["timeoff_status"] == "approved", "timeoff_status should be transmitted from series"
+        assert data["travel_status"] == "booked", "travel_status should be transmitted from series"
+
+        # Verify logistics date fields are transmitted
+        assert data["ticket_purchase_date"] == "2026-10-15", "ticket_purchase_date should be transmitted from series"
+        assert data["timeoff_booking_date"] == "2026-09-01", "timeoff_booking_date should be transmitted from series"
+        assert data["travel_booking_date"] == "2026-11-01", "travel_booking_date should be transmitted from series"

--- a/backend/tests/integration/test_series_cleanup.py
+++ b/backend/tests/integration/test_series_cleanup.py
@@ -1,0 +1,288 @@
+"""
+Test series cleanup when deleting events.
+
+Issue: Deleting events from a series did not properly handle cleanup:
+- Deleting next-to-last event should convert remaining event to standalone
+- Deleting last event should clean up deadline entries
+- Single event deletion should update series total
+
+Fix: soft_delete now always updates series total and handles cleanup logic.
+"""
+import pytest
+from datetime import date
+
+from backend.src.models import Category
+
+
+class TestSeriesCleanup:
+    """Test series cleanup when deleting events."""
+
+    @pytest.fixture
+    def test_category(self, test_db_session, test_team):
+        """Create a test category."""
+        category = Category(
+            name="Test Cleanup Category",
+            icon="plane",
+            color="#3B82F6",
+            is_active=True,
+            display_order=0,
+            team_id=test_team.id,
+        )
+        test_db_session.add(category)
+        test_db_session.commit()
+        test_db_session.refresh(category)
+        return category
+
+    def test_delete_single_event_updates_series_total(self, test_client, test_category):
+        """Deleting a single event from a series should update total_events."""
+        # Create a series with 3 events
+        response = test_client.post(
+            "/api/events/series",
+            json={
+                "title": "Three Day Series",
+                "category_guid": test_category.guid,
+                "event_dates": ["2026-08-10", "2026-08-11", "2026-08-12"],
+            },
+        )
+        assert response.status_code == 201
+        events = response.json()
+        assert len(events) == 3
+
+        # All events should show series_total=3
+        for event in events:
+            assert event["series_total"] == 3
+
+        # Delete the first event (single scope)
+        delete_resp = test_client.delete(
+            f"/api/events/{events[0]['guid']}",
+            params={"scope": "single"},
+        )
+        assert delete_resp.status_code == 200
+
+        # Remaining events should now show series_total=2
+        detail = test_client.get(f"/api/events/{events[1]['guid']}")
+        assert detail.status_code == 200
+        assert detail.json()["series_total"] == 2
+
+    def test_delete_next_to_last_converts_to_standalone(self, test_client, test_category):
+        """Deleting next-to-last event should convert remaining event to standalone."""
+        # Create a series with 2 events
+        response = test_client.post(
+            "/api/events/series",
+            json={
+                "title": "Two Day Series",
+                "category_guid": test_category.guid,
+                "event_dates": ["2026-09-10", "2026-09-11"],
+                "ticket_required": True,  # Set logistics on series
+            },
+        )
+        assert response.status_code == 201
+        events = response.json()
+        assert len(events) == 2
+
+        # Both events should be part of series
+        for event in events:
+            assert event["series_guid"] is not None
+            assert event["series_total"] == 2
+
+        # Remember the second event GUID
+        remaining_event_guid = events[1]["guid"]
+
+        # Delete the first event
+        delete_resp = test_client.delete(
+            f"/api/events/{events[0]['guid']}",
+            params={"scope": "single"},
+        )
+        assert delete_resp.status_code == 200
+
+        # The remaining event should now be standalone
+        detail = test_client.get(f"/api/events/{remaining_event_guid}")
+        assert detail.status_code == 200
+        data = detail.json()
+
+        # Should no longer be part of a series
+        assert data["series_guid"] is None, "Event should be converted to standalone"
+        assert data["sequence_number"] is None, "Sequence number should be cleared"
+        assert data["series_total"] is None, "Series total should be None for standalone"
+
+        # Should have inherited logistics from series
+        assert data["ticket_required"] is True, "Should retain ticket_required from series"
+
+        # Title should be copied from series
+        assert data["title"] == "Two Day Series"
+
+    def test_delete_last_event_cleans_up_deadline(self, test_client, test_category):
+        """Deleting all events should soft-delete the deadline entry."""
+        # Create a series with 2 events and a deadline
+        response = test_client.post(
+            "/api/events/series",
+            json={
+                "title": "Series With Deadline",
+                "category_guid": test_category.guid,
+                "event_dates": ["2026-10-10", "2026-10-11"],
+                "deadline_date": "2026-10-20",
+            },
+        )
+        assert response.status_code == 201
+        events = response.json()
+
+        # Should have 3 events (2 regular + 1 deadline)
+        assert len(events) == 3
+        deadline_events = [e for e in events if e.get("is_deadline")]
+        regular_events = [e for e in events if not e.get("is_deadline")]
+        assert len(deadline_events) == 1
+        assert len(regular_events) == 2
+
+        deadline_guid = deadline_events[0]["guid"]
+
+        # Delete both regular events (scope=all on one of them)
+        delete_resp = test_client.delete(
+            f"/api/events/{regular_events[0]['guid']}",
+            params={"scope": "all"},
+        )
+        assert delete_resp.status_code == 200
+
+        # The deadline entry should also be soft-deleted
+        deadline_detail = test_client.get(f"/api/events/{deadline_guid}")
+        # Should be 404 because it's soft-deleted and include_deleted defaults to false
+        assert deadline_detail.status_code == 404
+
+        # Can still find it with include_deleted=true
+        deadline_detail_with_deleted = test_client.get(
+            f"/api/events/{deadline_guid}",
+            params={"include_deleted": True},
+        )
+        assert deadline_detail_with_deleted.status_code == 200
+        assert deadline_detail_with_deleted.json()["deleted_at"] is not None
+
+    def test_delete_from_series_excludes_deadline_from_count(
+        self, test_client, test_category
+    ):
+        """Verify deadline entry is not counted when updating series total."""
+        # Create a series with 2 events and a deadline
+        response = test_client.post(
+            "/api/events/series",
+            json={
+                "title": "Series Count Test",
+                "category_guid": test_category.guid,
+                "event_dates": ["2026-11-10", "2026-11-11"],
+                "deadline_date": "2026-11-20",
+            },
+        )
+        assert response.status_code == 201
+        events = response.json()
+
+        regular_events = [e for e in events if not e.get("is_deadline")]
+        assert len(regular_events) == 2
+
+        # series_total should be 2 (not 3)
+        assert regular_events[0]["series_total"] == 2
+
+        # Delete one regular event
+        delete_resp = test_client.delete(
+            f"/api/events/{regular_events[0]['guid']}",
+            params={"scope": "single"},
+        )
+        assert delete_resp.status_code == 200
+
+        # The remaining event should now be standalone (series_total was 2, now 1)
+        detail = test_client.get(f"/api/events/{regular_events[1]['guid']}")
+        data = detail.json()
+
+        # Should be converted to standalone
+        assert data["series_guid"] is None
+        assert data["series_total"] is None
+
+    def test_convert_to_standalone_preserves_event_overrides(
+        self, test_client, test_category, test_db_session, test_team
+    ):
+        """When converting to standalone, event-level overrides should be preserved."""
+        # Create series via API
+        response = test_client.post(
+            "/api/events/series",
+            json={
+                "title": "Override Test Series",
+                "category_guid": test_category.guid,
+                "event_dates": ["2026-12-10", "2026-12-11"],
+                "ticket_required": True,  # Series default
+            },
+        )
+        assert response.status_code == 201
+        events = response.json()
+
+        # Set explicit override on second event
+        update_resp = test_client.patch(
+            f"/api/events/{events[1]['guid']}",
+            json={"ticket_required": False},  # Override series default
+        )
+        assert update_resp.status_code == 200
+
+        # Delete first event, converting second to standalone
+        delete_resp = test_client.delete(
+            f"/api/events/{events[0]['guid']}",
+            params={"scope": "single"},
+        )
+        assert delete_resp.status_code == 200
+
+        # The remaining event (now standalone) should keep its override
+        detail = test_client.get(f"/api/events/{events[1]['guid']}")
+        data = detail.json()
+
+        assert data["series_guid"] is None, "Should be standalone"
+        assert data["ticket_required"] is False, "Should keep event-level override"
+
+    def test_convert_to_standalone_creates_deadline_entry(self, test_client, test_category):
+        """When converting to standalone, a deadline entry should be created if deadline exists."""
+        # Create a series with 2 events and a deadline
+        response = test_client.post(
+            "/api/events/series",
+            json={
+                "title": "Series With Deadline",
+                "category_guid": test_category.guid,
+                "event_dates": ["2026-12-15", "2026-12-16"],
+                "deadline_date": "2026-12-25",
+            },
+        )
+        assert response.status_code == 201
+        events = response.json()
+
+        # Should have 3 events (2 regular + 1 deadline)
+        regular_events = [e for e in events if not e.get("is_deadline")]
+        series_deadline = [e for e in events if e.get("is_deadline")]
+        assert len(regular_events) == 2
+        assert len(series_deadline) == 1
+
+        remaining_event_guid = regular_events[1]["guid"]
+        series_deadline_guid = series_deadline[0]["guid"]
+
+        # Delete the first event
+        delete_resp = test_client.delete(
+            f"/api/events/{regular_events[0]['guid']}",
+            params={"scope": "single"},
+        )
+        assert delete_resp.status_code == 200
+
+        # The remaining event should be standalone
+        detail = test_client.get(f"/api/events/{remaining_event_guid}")
+        assert detail.status_code == 200
+        data = detail.json()
+        assert data["series_guid"] is None, "Event should be standalone"
+        assert data["deadline_date"] == "2026-12-25", "Deadline date should be preserved"
+
+        # The series deadline entry should be soft-deleted
+        series_deadline_detail = test_client.get(f"/api/events/{series_deadline_guid}")
+        assert series_deadline_detail.status_code == 404, "Series deadline should be deleted"
+
+        # A new standalone deadline entry should exist for the remaining event
+        # Find it by listing events for that date
+        list_resp = test_client.get(
+            "/api/events",
+            params={"start_date": "2026-12-25", "end_date": "2026-12-25"},
+        )
+        assert list_resp.status_code == 200
+        deadline_events = [e for e in list_resp.json() if e.get("is_deadline")]
+        assert len(deadline_events) == 1, "A standalone deadline entry should exist"
+
+        # The standalone deadline should be linked to the remaining event
+        standalone_deadline = deadline_events[0]
+        assert standalone_deadline["title"] == "Series With Deadline - Deadline"

--- a/frontend/src/components/events/LocationPicker.tsx
+++ b/frontend/src/components/events/LocationPicker.tsx
@@ -12,7 +12,7 @@
  */
 
 import * as React from 'react'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import { Check, ChevronsUpDown, MapPin, Search, Loader2, Plus, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -40,6 +40,12 @@ import type { Location, GeocodeResponse, LocationCreateRequest } from '@/contrac
 // Types
 // ============================================================================
 
+/** Logistics hints from location defaults */
+export interface LocationLogisticsHint {
+  timeoff_required?: boolean
+  travel_required?: boolean
+}
+
 export interface LocationPickerProps {
   /** Category GUID to filter known locations (required for category matching) */
   categoryGuid: string | null
@@ -49,6 +55,8 @@ export interface LocationPickerProps {
   onChange: (location: Location | null) => void
   /** Called when a location with timezone is selected (for timezone suggestion) */
   onTimezoneHint?: (timezone: string) => void
+  /** Called when a location with logistics defaults is selected */
+  onLogisticsHint?: (hint: LocationLogisticsHint) => void
   /** Placeholder text */
   placeholder?: string
   /** Disable the picker */
@@ -66,6 +74,7 @@ export function LocationPicker({
   value,
   onChange,
   onTimezoneHint,
+  onLogisticsHint,
   placeholder = 'Select or enter location...',
   disabled = false,
   className,
@@ -110,6 +119,13 @@ export function LocationPicker({
     onChange(location)
     if (location.timezone && onTimezoneHint) {
       onTimezoneHint(location.timezone)
+    }
+    // Suggest logistics defaults if available (use nullish checks to preserve explicit false)
+    if (onLogisticsHint && (location.timeoff_required_default != null || location.travel_required_default != null)) {
+      onLogisticsHint({
+        timeoff_required: location.timeoff_required_default ?? undefined,
+        travel_required: location.travel_required_default ?? undefined,
+      })
     }
     setOpen(false)
   }
@@ -175,6 +191,13 @@ export function LocationPicker({
       onChange(newLocation)
       if (newLocation.timezone && onTimezoneHint) {
         onTimezoneHint(newLocation.timezone)
+      }
+      // Suggest logistics defaults if available (use nullish checks to preserve explicit false)
+      if (onLogisticsHint && (newLocation.timeoff_required_default != null || newLocation.travel_required_default != null)) {
+        onLogisticsHint({
+          timeoff_required: newLocation.timeoff_required_default ?? undefined,
+          travel_required: newLocation.travel_required_default ?? undefined,
+        })
       }
       setOpen(false)
     } catch (err) {

--- a/frontend/src/components/events/LogisticsSection.tsx
+++ b/frontend/src/components/events/LogisticsSection.tsx
@@ -227,6 +227,7 @@ export function LogisticsSection({
                   onChange={(date) => updateField('ticket_purchase_date', date || null)}
                   placeholder="Select date"
                   disabled={disabled}
+                  clearable
                 />
               </div>
             </div>
@@ -286,6 +287,7 @@ export function LogisticsSection({
                   onChange={(date) => updateField('timeoff_booking_date', date || null)}
                   placeholder="Select date"
                   disabled={disabled}
+                  clearable
                 />
               </div>
             </div>
@@ -345,6 +347,7 @@ export function LogisticsSection({
                   onChange={(date) => updateField('travel_booking_date', date || null)}
                   placeholder="Select date"
                   disabled={disabled}
+                  clearable
                 />
               </div>
             </div>

--- a/frontend/src/contracts/api/event-api.ts
+++ b/frontend/src/contracts/api/event-api.ts
@@ -197,6 +197,14 @@ export interface EventSeriesCreateRequest {
   timeoff_required?: boolean
   travel_required?: boolean
 
+  // Logistics status and dates (applied to all events in series)
+  ticket_status?: TicketStatus | null
+  ticket_purchase_date?: string | null    // ISO date
+  timeoff_status?: TimeoffStatus | null
+  timeoff_booking_date?: string | null    // ISO date
+  travel_status?: TravelStatus | null
+  travel_booking_date?: string | null     // ISO date
+
   // Deadline for deliverables (creates a deadline entry in the calendar)
   deadline_date?: string | null       // ISO date (e.g., client delivery date)
   deadline_time?: string | null       // HH:MM format (e.g., competition cutoff time)

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -360,8 +360,8 @@ export default function EventsPage() {
         open={selectedEvent !== null}
         onOpenChange={(open) => !open && setSelectedEvent(null)}
       >
-        <DialogContent>
-          <DialogHeader>
+        <DialogContent className="max-w-lg max-h-[90vh] flex flex-col">
+          <DialogHeader className="flex-shrink-0">
             <DialogTitle>{selectedEvent?.title}</DialogTitle>
             <DialogDescription>
               {selectedEvent && (
@@ -377,7 +377,7 @@ export default function EventsPage() {
             </DialogDescription>
           </DialogHeader>
           {selectedEvent && (
-            <div className="space-y-4 pt-4">
+            <div className="space-y-4 pt-4 overflow-y-auto flex-1">
               {/* Description */}
               {selectedEvent.description && (
                 <div>
@@ -601,7 +601,7 @@ export default function EventsPage() {
           )}
           {/* Edit/Delete buttons hidden for deadline entries (T036-T037) */}
           {selectedEvent && !selectedEvent.is_deadline && (
-            <DialogFooter className="gap-2 sm:gap-0">
+            <DialogFooter className="flex-shrink-0 gap-2 sm:gap-0">
               <Button variant="outline" onClick={handleEditClick}>
                 <Pencil className="h-4 w-4 mr-2" />
                 Edit


### PR DESCRIPTION
## Summary

This PR addresses multiple issues in the event logistics workflow:

- **Logistics inheritance**: Series events now properly inherit boolean flags (`ticket_required`, `timeoff_required`, `travel_required`) from their parent series
- **Status/date transmission**: Status and date fields are now properly passed from series creation to individual events
- **Series cleanup**: Deleting next-to-last event converts remaining event to standalone; deleting last event cleans up deadline entries
- **Logistics hints**: Selecting a location or organizer with defaults now suggests logistics values in the form
- **Date picker clearability**: Date fields in logistics section can now be cleared
- **Dialog scrolling**: Event detail dialog now scrolls when content overflows

## Changes

### Backend
- Add logistics status/date fields to `EventSeriesCreate` schema
- Update `create_series` to accept and pass status/date fields to events  
- Fix `build_event_detail_response` to preserve inherited logistics values
- Add `_cleanup_series_if_needed` for proper series dissolution
- Exclude deadline entries from series total count

### Frontend
- Add logistics status/date fields to `EventSeriesCreateRequest` interface
- Send status/date fields when creating series in `EventForm`
- Add `onLogisticsHint` callback to `LocationPicker`
- Add `onTicketRequiredHint` callback to `OrganizerPicker`
- Add `clearable` prop to date pickers in `LogisticsSection`
- Add `max-height` and overflow scrolling to event detail dialog

### Tests
- Add `test_logistics_inheritance.py` (4 tests)
- Add `test_series_cleanup.py` (5 tests)

## Test plan

- [ ] Create an event series with an organizer that has ticket_required default - verify field is suggested
- [ ] Create an event series with a location that has timeoff/travel defaults - verify fields are suggested
- [ ] Create an event series with logistics status and dates filled - verify individual events have those values
- [ ] Delete next-to-last event in a series - verify remaining event becomes standalone
- [ ] Delete all events in a series with deadline - verify deadline entry is also deleted
- [ ] Set a date in logistics section - verify X button appears and clears the date
- [ ] Open event detail with lots of content - verify dialog scrolls properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logistics status and booking date tracking for tickets, time off, and travel on event series
  * Smart logistics suggestions from location and organizer; logistics fields included on event submit
  * Logistics date pickers are now clearable

* **Behavior Changes**
  * Series cleanup on deletions: deadlines are handled automatically and lone remaining events become standalone preserving data

* **Tests**
  * Added integration tests for logistics inheritance and series cleanup

* **Style**
  * Improved event detail dialog scrolling and layout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->