### PR TITLE
Fix performer category validation for series events

### DIFF
--- a/backend/src/services/event_service.py
+++ b/backend/src/services/event_service.py
@@ -1990,8 +1990,8 @@ class EventService:
         event = self.get_by_guid(event_guid)
         performer = self._get_performer_by_guid(performer_guid)
 
-        # Validate category match
-        if performer.category_id != event.category_id:
+        # Validate category match (use effective_category_id for series events)
+        if performer.category_id != event.effective_category_id:
             raise ValidationError(
                 f"Performer '{performer.name}' category does not match event category",
                 field="performer_guid"


### PR DESCRIPTION
## Summary
- Fixed bug where adding a performer to an event in a series always failed validation
- Series events have `category_id=None` (they inherit from the series), but the validation was comparing directly with `event.category_id`
- Changed to use `event.effective_category_id` which correctly falls back to the series category

## Root Cause
In `add_performer_to_event()`, the category validation compared:
- `performer.category_id` = actual category ID (e.g., 5)
- `event.category_id` = `None` (for series events that inherit from series)

This always resulted in a mismatch, even when the performer's category matched the series category.

## Test plan
- [x] Verified all existing tests pass (39 performer tests, 74 events API tests)
- [ ] Manual test: Add a performer to an event that is part of a series

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed category validation when adding performers to series-linked events, now correctly accounting for categories inherited from a series instead of relying solely on individual event category settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->