### PR TITLE
Fix calendar not showing events for trailing days in 6-week grid

### DIFF
--- a/frontend/src/services/events.ts
+++ b/frontend/src/services/events.ts
@@ -114,13 +114,9 @@ export const listEventsForCalendarView = async (year: number, month: number): Pr
   const startDate = new Date(firstOfMonth)
   startDate.setDate(startDate.getDate() - startDayOfWeek)
 
-  // Get the last day of the month
-  const lastOfMonth = new Date(year, month, 0)
-
-  // End on the Saturday after or on the last of the month
-  const endDayOfWeek = lastOfMonth.getDay()
-  const endDate = new Date(lastOfMonth)
-  endDate.setDate(endDate.getDate() + (6 - endDayOfWeek))
+  // End after exactly 42 days (6 weeks) to match the calendar grid
+  const endDate = new Date(startDate)
+  endDate.setDate(endDate.getDate() + 41)
 
   const formatDate = (d: Date) =>
     `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`


### PR DESCRIPTION
## Summary
- The calendar renders a fixed 6-week (42-day) grid, but listEventsForCalendarView only fetched events through the Saturday after the last day of the month
- For months like March 2026 (starts on Sunday), the grid 6th row shows April 5-11, but the API only fetched through April 4 -- leaving up to a full week of visible days without events
- Fixed by computing the API end date as startDate + 41 days, matching the grid exactly

## Test plan
- [ ] Navigate to March 2026 -- verify events on April 5-11 (6th row) are visible
- [ ] Navigate to February 2026 -- verify events in adjacent month days (Jan/March) appear
- [ ] Navigate through several months -- verify no missing or duplicate events
- [ ] Verify no regressions on months where the grid was already correct (e.g., months starting mid-week)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar view consistency by standardizing the display to a consistent 6-week grid layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->