### PR TITLE
Address reviewer feedback for conflict visualization feature

### DIFF
--- a/backend/src/services/conflict_service.py
+++ b/backend/src/services/conflict_service.py
@@ -369,7 +369,7 @@ class ConflictService:
     @staticmethod
     def _time_overlap_detail(a: Event, b: Event) -> str:
         """Generate human-readable detail for a time overlap."""
-        date_str = a.event_date.strftime("%b %-d")
+        date_str = f"{a.event_date.strftime('%b')} {a.event_date.day}"
         if a.is_all_day or b.is_all_day:
             return f"All-day event conflict on {date_str}"
         if a.start_time and a.end_time and b.start_time and b.end_time:

--- a/backend/src/services/event_service.py
+++ b/backend/src/services/event_service.py
@@ -2085,7 +2085,16 @@ class EventService:
 
         Runs conflict detection for a window around the event date and sends
         notifications for any unresolved conflict edges found. Errors are
-        suppressed to avoid blocking the main create/update operation.
+        suppressed to avoid blocking the main create/update operation;
+        callers should not expect exceptions to propagate.
+
+        Args:
+            team_id (int): Team identifier for tenant isolation.
+            event_date (date): Date around which conflicts are detected
+                (a +/-7 day window is used).
+
+        Returns:
+            None
         """
         try:
             from backend.src.services.conflict_service import ConflictService

--- a/backend/tests/integration/test_conflict_endpoints.py
+++ b/backend/tests/integration/test_conflict_endpoints.py
@@ -20,6 +20,15 @@ class TestConflictDetection:
 
     @pytest.fixture
     def category(self, test_db_session, test_team):
+        """Create a test category for conflict detection tests.
+
+        Args:
+            test_db_session: SQLAlchemy test database session.
+            test_team: Test team instance providing team_id.
+
+        Returns:
+            Category: A persisted Category instance with id and team_id set.
+        """
         cat = Category(
             name="Conflict Test Category",
             icon="calendar",
@@ -170,7 +179,7 @@ class TestConflictDetection:
         assert response.status_code == 200
         assert response.json()["conflict_groups"] == []
 
-    def test_time_overlap_detected(self, test_client, overlapping_events):
+    def test_time_overlap_detected(self, test_client, _overlapping_events):
         """Two overlapping same-day events → one conflict group."""
         response = test_client.get(
             "/api/events/conflicts",
@@ -186,7 +195,7 @@ class TestConflictDetection:
         assert group["edges"][0]["conflict_type"] == "time_overlap"
         assert group["status"] == "unresolved"
 
-    def test_distance_conflict_detected(self, test_client, distant_events):
+    def test_distance_conflict_detected(self, test_client, _distant_events):
         """Distant consecutive-day events → distance conflict."""
         response = test_client.get(
             "/api/events/conflicts",
@@ -203,7 +212,7 @@ class TestConflictDetection:
         distance_edges = [e for e in all_edges if e["conflict_type"] == "distance"]
         assert len(distance_edges) >= 1
 
-    def test_scored_events_in_group(self, test_client, overlapping_events):
+    def test_scored_events_in_group(self, test_client, _overlapping_events):
         """Events in conflict groups include quality scores."""
         response = test_client.get(
             "/api/events/conflicts",
@@ -235,7 +244,7 @@ class TestConflictDetection:
         response = test_client.get("/api/events/conflicts")
         assert response.status_code == 422
 
-    def test_response_summary_structure(self, test_client, overlapping_events):
+    def test_response_summary_structure(self, test_client, _overlapping_events):
         """Summary includes all required counts."""
         response = test_client.get(
             "/api/events/conflicts",

--- a/backend/tests/unit/test_conflict_notification.py
+++ b/backend/tests/unit/test_conflict_notification.py
@@ -25,7 +25,14 @@ from backend.src.services.notification_service import (
 
 @pytest.fixture
 def notification_service(test_db_session):
-    """Create a NotificationService with test VAPID config."""
+    """Create a NotificationService with test VAPID config.
+
+    Args:
+        test_db_session: SQLAlchemy test database session.
+
+    Returns:
+        NotificationService: Configured with test VAPID private key and claims.
+    """
     return NotificationService(
         db=test_db_session,
         vapid_private_key="test-private-key",
@@ -35,7 +42,16 @@ def notification_service(test_db_session):
 
 @pytest.fixture
 def enabled_user(test_db_session, test_user):
-    """Set up a user with conflict notifications enabled."""
+    """Set up a user with conflict notifications enabled.
+
+    Args:
+        test_db_session: SQLAlchemy test database session.
+        test_user: Test user instance to enable notifications on.
+
+    Returns:
+        User: The test_user with conflict notifications enabled
+            (preferences_json updated and committed).
+    """
     test_user.preferences_json = json.dumps({
         "notifications": {
             **DEFAULT_PREFERENCES,
@@ -96,7 +112,7 @@ class TestNotifyConflictDetected:
         mock_deliver.assert_called_once()
 
     def test_suppressed_when_preference_disabled(
-        self, notification_service, test_user, test_team,
+        self, notification_service, _test_user, test_team,
     ):
         """Should not send when user has notifications disabled (default)."""
         # test_user has default prefs (enabled=False)
@@ -115,7 +131,7 @@ class TestNotifyConflictDetected:
 
     @patch("backend.src.services.notification_service.NotificationService.deliver_push")
     def test_notification_content(
-        self, mock_deliver, notification_service, enabled_user, test_team,
+        self, mock_deliver, notification_service, _enabled_user, test_team,
         test_db_session,
     ):
         """Should include conflict type and event titles in notification body."""

--- a/frontend/src/components/events/EventCalendar.tsx
+++ b/frontend/src/components/events/EventCalendar.tsx
@@ -579,7 +579,10 @@ export const EventCalendar = ({
                   }]
                 : []
 
-              const allBadges = [...badges, ...conflictBadges]
+              // Prepend conflict badge so it is always visible
+              const allBadges = [...conflictBadges, ...badges]
+              const visibleBadges = allBadges.slice(0, MAX_VISIBLE_BADGES)
+              const overflowCount = Math.max(0, allBadges.length - MAX_VISIBLE_BADGES)
 
               return (
                 <CompactCalendarCell
@@ -588,8 +591,8 @@ export const EventCalendar = ({
                   dayNumber={day.date.getDate()}
                   isCurrentMonth={day.isCurrentMonth}
                   isToday={day.isToday}
-                  badges={allBadges.slice(0, MAX_VISIBLE_BADGES)}
-                  overflowCount={Math.max(0, allBadges.length - MAX_VISIBLE_BADGES)}
+                  badges={visibleBadges}
+                  overflowCount={overflowCount}
                   totalEventCount={day.events.length}
                   onClick={(date) => onDayClick?.(date)}
                   {...commonProps}

--- a/frontend/src/components/events/RadarComparisonDialog.tsx
+++ b/frontend/src/components/events/RadarComparisonDialog.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Building2, Check, Clock, MapPin, SkipForward, Users } from 'lucide-react'
+import { toast } from 'sonner'
 import {
   Dialog,
   DialogContent,
@@ -47,7 +48,7 @@ export function RadarComparisonDialog({
   referenceDate,
   onResolved,
 }: RadarComparisonDialogProps) {
-  const { resolve, loading } = useResolveConflict({
+  const { resolve, loading, error } = useResolveConflict({
     onSuccess: () => {
       onResolved?.()
       onOpenChange(false)
@@ -68,8 +69,8 @@ export function RadarComparisonDialog({
           attendance: e.guid === confirmedGuid ? 'planned' as const : 'skipped' as const,
         })),
       })
-    } catch {
-      // Error handled by hook
+    } catch (err: any) {
+      toast.error(err.userMessage || 'Failed to resolve conflict')
     }
   }
 

--- a/frontend/src/components/events/TimelinePlanner.tsx
+++ b/frontend/src/components/events/TimelinePlanner.tsx
@@ -312,14 +312,14 @@ export function TimelinePlanner({
       ) : (
         <div
           className="space-y-0.5"
-          role="listbox"
+          role="list"
           aria-label="Timeline events"
           onKeyDown={handleTimelineKeyDown}
         >
           {segmentByConflictGroup(sortedEvents, conflictGroups).map((segment, segIdx) => {
             if (segment.type === 'single') {
               return (
-                <div key={segment.event.guid} className="ml-5" role="option" aria-selected={false}>
+                <div key={segment.event.guid} className="ml-5" role="listitem">
                   <TimelineEventMarker
                     ref={handle => setMarkerRef(segment.event.guid, handle)}
                     event={segment.event}
@@ -340,7 +340,7 @@ export function TimelinePlanner({
                   />
                 )}
                 {segment.events.map(event => (
-                  <div key={event.guid} className="ml-5" role="option" aria-selected={false}>
+                  <div key={event.guid} className="ml-5" role="listitem">
                     <TimelineEventMarker
                       ref={handle => setMarkerRef(event.guid, handle)}
                       event={event}


### PR DESCRIPTION
Backend:
- Add Args/Returns docstrings to get_conflict_service, detect_conflicts, resolve_conflict, get_event_score endpoints (events.py)
- Fix non-portable date formatting in _time_overlap_detail: replace strftime("%b %-d") with cross-platform f-string approach (conflict_service.py)
- Add Args/Returns docstring to _notify_new_conflicts (event_service.py)
- Add docstring with Args/Returns to category fixture, rename unused fixture params with underscore prefix (test_conflict_endpoints.py)
- Update fixture docstrings with Args/Returns, rename unused fixture params with underscore prefix (test_conflict_notification.py)

Frontend:
- Fix conflict badge clipping by prepending conflict badges before category badges so they are always visible (EventCalendar.tsx)
- Surface resolution errors via toast.error instead of silently swallowing them (RadarComparisonDialog.tsx)
- Fix broken listbox semantics: switch from role="listbox"/role="option" with hardcoded aria-selected=false to role="list"/role="listitem" (TimelinePlanner.tsx)

https://claude.ai/code/session_017kSRFNQrUHW1oowEt4nPtE