### PR TITLE
Fix SQLAlchemy subquery coercion warning

### DIFF
--- a/backend/src/services/agent_service.py
+++ b/backend/src/services/agent_service.py
@@ -1105,7 +1105,7 @@ class AgentService:
             Job.team_id == team_id,
             Job.status.in_([JobStatus.ASSIGNED, JobStatus.RUNNING]),
             Job.agent_id.isnot(None)
-        ).subquery()
+        ).scalar_subquery()
 
         idle_count = self.db.query(func.count(Agent.id)).filter(
             Agent.team_id == team_id,


### PR DESCRIPTION
## Summary
- Use `scalar_subquery()` instead of `subquery()` when selecting a single column for use in an `IN()` clause
- Eliminates the SAWarning: "Coercing Subquery object into a select() for use in IN()"

## Test plan
- [x] Start the webserver and connect via WebSocket to `/api/agent/v1/ws/pool-status`
- [x] Verify no SQLAlchemy warnings appear in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)