### PR TITLE
Fix missing conflict notification toggle and category label

### DIFF
--- a/backend/src/schemas/notifications.py
+++ b/backend/src/schemas/notifications.py
@@ -109,6 +109,7 @@ class NotificationPreferencesResponse(BaseModel):
     inflection_points: bool = True
     agent_status: bool = True
     deadline: bool = True
+    conflict: bool = True
     retry_warning: bool = False
     deadline_days_before: int = Field(3, ge=1, le=30)
     timezone: str = Field("UTC", description="IANA timezone identifier")
@@ -127,6 +128,7 @@ class NotificationPreferencesUpdate(BaseModel):
     inflection_points: Optional[bool] = None
     agent_status: Optional[bool] = None
     deadline: Optional[bool] = None
+    conflict: Optional[bool] = None
     retry_warning: Optional[bool] = None
     deadline_days_before: Optional[int] = Field(default=None, ge=1, le=30)
     timezone: Optional[str] = Field(

--- a/frontend/src/components/profile/NotificationPreferences.tsx
+++ b/frontend/src/components/profile/NotificationPreferences.tsx
@@ -55,6 +55,7 @@ const CATEGORY_TOGGLES: {
   { key: 'inflection_point', prefKey: 'inflection_points' },
   { key: 'agent_status', prefKey: 'agent_status' },
   { key: 'deadline', prefKey: 'deadline' },
+  { key: 'conflict', prefKey: 'conflict' },
   { key: 'retry_warning', prefKey: 'retry_warning' },
 ]
 

--- a/frontend/src/contracts/api/notification-api.ts
+++ b/frontend/src/contracts/api/notification-api.ts
@@ -62,6 +62,7 @@ export interface NotificationPreferencesResponse {
   inflection_points: boolean
   agent_status: boolean
   deadline: boolean
+  conflict: boolean
   retry_warning: boolean
   deadline_days_before: number
   timezone: string
@@ -77,6 +78,7 @@ export interface NotificationPreferencesUpdateRequest {
   inflection_points?: boolean
   agent_status?: boolean
   deadline?: boolean
+  conflict?: boolean
   retry_warning?: boolean
   deadline_days_before?: number
   timezone?: string

--- a/frontend/src/contracts/domain-labels.ts
+++ b/frontend/src/contracts/domain-labels.ts
@@ -29,6 +29,7 @@ import {
   ServerCrash,
   Clock,
   RefreshCw,
+  AlertTriangle,
   type LucideIcon
 } from 'lucide-react'
 
@@ -413,6 +414,7 @@ export type NotificationCategory =
   | 'inflection_point'
   | 'agent_status'
   | 'deadline'
+  | 'conflict'
   | 'retry_warning'
 
 /**
@@ -423,6 +425,7 @@ export const NOTIFICATION_CATEGORY_LABELS: Record<NotificationCategory, string> 
   inflection_point: 'Inflection Points',
   agent_status: 'Agent Status',
   deadline: 'Deadlines',
+  conflict: 'Scheduling Conflicts',
   retry_warning: 'Retry Warnings'
 }
 
@@ -434,6 +437,7 @@ export const NOTIFICATION_CATEGORY_ICONS: Record<NotificationCategory, LucideIco
   inflection_point: TrendingUp,
   agent_status: ServerCrash,
   deadline: Clock,
+  conflict: AlertTriangle,
   retry_warning: RefreshCw
 }
 
@@ -445,6 +449,7 @@ export const NOTIFICATION_CATEGORY_DESCRIPTIONS: Record<NotificationCategory, st
   inflection_point: 'When analysis detects changes in a collection',
   agent_status: 'When agent pool goes offline, errors, or recovers',
   deadline: 'Reminders before event deadlines approach',
+  conflict: 'When new scheduling conflicts are detected between events',
   retry_warning: 'When a job reaches its final retry attempt'
 }
 
@@ -459,6 +464,7 @@ export const NOTIFICATION_CATEGORY_BADGE_VARIANT: Record<
   inflection_point: 'secondary',
   agent_status: 'warning',
   deadline: 'secondary',
+  conflict: 'warning',
   retry_warning: 'muted'
 }
 

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -64,6 +64,7 @@ const NOTIFICATION_CATEGORY_VALUES: NotificationCategory[] = [
   'inflection_point',
   'agent_status',
   'deadline',
+  'conflict',
   'retry_warning',
 ]
 


### PR DESCRIPTION
## Summary
- Add `conflict` field to backend notification preference schemas (`NotificationPreferencesResponse`, `NotificationPreferencesUpdate`)
- Add `conflict` to frontend API type definitions and `NotificationCategory` union type
- Register conflict category in domain labels: label ("Scheduling Conflicts"), icon (`AlertTriangle`), description, and badge variant (`warning`)
- Add conflict toggle to `NotificationPreferences` component and filter to `NotificationsPage`

## Test plan
- [x] All 65 notification backend tests pass
- [x] Frontend TypeScript type-check passes (no new errors)
- [x] Verify conflict toggle appears in user notification preferences
- [x] Verify conflict notifications show "Scheduling Conflicts" badge in list view
- [x] Verify conflict category appears in notification filter dropdown

Fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Scheduling Conflicts" notification category. Users can now receive alerts when scheduling conflicts are detected between events and manage this notification preference in their settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->