### PR TITLE
Add AlertTriangle icon to ICON_MAP for system use

### DIFF
--- a/frontend/src/components/settings/CategoryForm.tsx
+++ b/frontend/src/components/settings/CategoryForm.tsx
@@ -48,6 +48,8 @@ import {
   Crown,
   Briefcase,
   Calendar,
+  // System icons (not in user-facing picker)
+  AlertTriangle,
   type LucideIcon
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -127,10 +129,15 @@ export const AVAILABLE_ICONS: IconOption[] = [
 
 /**
  * Map of icon names to their components for quick lookup.
+ * Includes user-selectable icons from AVAILABLE_ICONS plus system icons
+ * (e.g., conflict indicators) that aren't shown in the category picker.
  */
-export const ICON_MAP: Record<string, LucideIcon> = Object.fromEntries(
-  AVAILABLE_ICONS.map(({ name, icon }) => [name, icon])
-)
+export const ICON_MAP: Record<string, LucideIcon> = {
+  ...Object.fromEntries(
+    AVAILABLE_ICONS.map(({ name, icon }) => [name, icon])
+  ),
+  'alert-triangle': AlertTriangle,
+}
 
 // ============================================================================
 // Form Schema


### PR DESCRIPTION
## Summary
Extended the icon system to support system-level icons that aren't exposed in the user-facing category picker. This enables the use of icons like `AlertTriangle` for internal features such as conflict indicators.

## Changes
- Imported `AlertTriangle` icon from lucide-react with a comment indicating it's for system use only
- Refactored `ICON_MAP` from a computed object to an explicit object literal that combines user-selectable icons from `AVAILABLE_ICONS` with system-only icons
- Updated the `ICON_MAP` JSDoc to clarify that it includes both user-selectable and system icons

## Implementation Details
- The `AlertTriangle` icon is now available via `ICON_MAP['alert-triangle']` for internal use
- User-facing icon picker (`AVAILABLE_ICONS`) remains unchanged, maintaining the existing user experience
- The spread operator pattern allows for easy addition of future system icons without modifying the `AVAILABLE_ICONS` array

https://claude.ai/code/session_01J4cz8SFtSx32YgJrak5BPh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alert-triangle icon to the available icon library, expanding visual indicator options for alerts and notifications throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->