### PR TITLE
Fix logistics preset filters being skipped when date range provided

### DIFF
--- a/backend/src/services/event_service.py
+++ b/backend/src/services/event_service.py
@@ -480,7 +480,10 @@ class EventService:
         elif preset == "upcoming_30d":
             # Fallback: original 30-day window when no explicit end_date
             query = query.filter(Event.event_date <= today + timedelta(days=30))
-        elif preset == "needs_tickets":
+        # Logistics presets without explicit end_date: no upper date bound
+
+        # Apply logistics-specific filters (independent of date window)
+        if preset == "needs_tickets":
             effective_ticket_required = case(
                 (Event.ticket_required.isnot(None), Event.ticket_required),
                 else_=EventSeries.ticket_required,


### PR DESCRIPTION
## Summary
Fixed a bug where logistics-specific filters (ticket_required, ticket_status, pto_required, travel_required) were being skipped when an explicit end_date was provided to the API. The issue was caused by an if/elif chain that would match the date window condition first, preventing the logistics filter branch from executing.

## Key Changes
- Changed the logistics preset filter logic from `elif` to `if` in `event_service.py`, allowing both date window filters and logistics-specific filters to be applied independently
- Added regression test `test_logistics_preset_with_date_range_applies_both_filters` to verify that logistics presets correctly combine date range filtering with their specific business logic filters

## Implementation Details
The fix ensures that when a preset like `needs_tickets`, `needs_pto`, or `needs_travel` is used with an explicit date range, both the date window AND the preset-specific filters are applied. Previously, the date window condition would match first in the if/elif chain and the logistics filters would never execute, causing incorrect results.

The test validates three scenarios:
- `needs_tickets` with wide date range returns only events where ticket_required=True AND ticket_status != 'ready'
- `needs_pto` with date range returns only PTO-required events
- `needs_travel` with date range returns only travel-required events

https://claude.ai/code/session_01SVg8s6pgkD5EpzWsMCxdGR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where logistics presets were not properly applied when combined with date range filters. Event filtering now correctly handles ticket requirements, PTO, and travel logistics presets alongside date parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->